### PR TITLE
Feature/product test

### DIFF
--- a/src/main/java/com/ecommerce/dto/product/ProductDto.java
+++ b/src/main/java/com/ecommerce/dto/product/ProductDto.java
@@ -37,6 +37,9 @@ public class ProductDto {
     @DecimalMin(value = "0.0", inclusive = false)
     private BigDecimal price;
 
+    @Builder.Default
+    private ProductStatus status = ProductStatus.IN_STOCK;
+
   }
 
   @Getter

--- a/src/main/java/com/ecommerce/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/ecommerce/exception/handler/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import com.ecommerce.exception.DataBaseException;
 import com.ecommerce.exception.EmailException;
 import com.ecommerce.exception.MemberException;
 import com.ecommerce.exception.NotFoundException;
+import com.ecommerce.exception.ProductException;
 import com.ecommerce.type.ResponseCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -52,6 +53,13 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ResponseDto> emailExceptionHandler(EmailException e) {
     log.error("{} 에러가 발생했습니다. (email)", e.getErrorCode());
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .body(ResponseDto.getResponseBody(e.getErrorCode()));
+  }
+
+  @ExceptionHandler(ProductException.class)
+  public ResponseEntity<ResponseDto> productExceptionHandler(ProductException e) {
+    log.error("{} 에러가 발생했습니다. (product)", e.getErrorCode());
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
         .body(ResponseDto.getResponseBody(e.getErrorCode()));
   }
 

--- a/src/main/java/com/ecommerce/service/product/ProductServiceImplement.java
+++ b/src/main/java/com/ecommerce/service/product/ProductServiceImplement.java
@@ -54,7 +54,7 @@ public class ProductServiceImplement implements ProductService {
                 .description(request.getDescription())
                 .stockQuantity(request.getStockQuantity())
                 .price(BigDecimal.valueOf(request.getPrice().doubleValue()))
-                .status(ProductStatus.IN_STOCK)
+                .status(request.getStatus())
                 .rating(BigDecimal.valueOf(0))
                 .member(member)
                 .build()

--- a/src/test/java/com/ecommerce/service/product/ProductServiceImplementTest.java
+++ b/src/test/java/com/ecommerce/service/product/ProductServiceImplementTest.java
@@ -1,0 +1,170 @@
+package com.ecommerce.service.product;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.ecommerce.dto.product.ProductDto;
+import com.ecommerce.entity.Member;
+import com.ecommerce.entity.Product;
+import com.ecommerce.exception.MemberException;
+import com.ecommerce.repository.ProductRepository;
+import com.ecommerce.service.auth.AuthService;
+import com.ecommerce.service.member.MemberService;
+import com.ecommerce.type.LoginType;
+import com.ecommerce.type.ProductStatus;
+import com.ecommerce.type.ResponseCode;
+import com.ecommerce.type.Role;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProductServiceImplementTest {
+
+  @Mock
+  private AuthService authService;
+
+  @Mock
+  private MemberService memberService;
+
+  @Mock
+  private ProductRepository productRepository;
+
+  @InjectMocks
+  private ProductServiceImplement productServiceImplement;
+
+  @Test
+  @DisplayName("상품 등록 - 성공")
+  void testCreateProduct_Success() {
+    // given
+    ProductDto.Request request = ProductDto.Request.builder()
+        .productName("testProductName")
+        .description("testProductDescription")
+        .stockQuantity(3)
+        .price(BigDecimal.valueOf(10000))
+        .status(ProductStatus.IN_STOCK)
+        .build();
+
+    Member member = Member.builder()
+        .memberId("testUser")
+        .memberName("test")
+        .email("test@email.com")
+        .password("encodedPassword")
+        .phoneNumber("01011112222")
+        .address("test시 test구 test로 111")
+        .role(Role.SELLER)
+        .loginType(LoginType.APP)
+        .build();
+
+    willDoNothing().given(authService)
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    given(memberService.getMemberByMemberId("testUser"))
+        .willReturn(member);
+
+    given(productRepository.save(any(Product.class)))
+        .willReturn(
+            Product.builder()
+                .productName("testProductName")
+                .description("testProductDescription")
+                .stockQuantity(3)
+                .price(BigDecimal.valueOf(10000.0))
+                .status(ProductStatus.IN_STOCK)
+                .rating(BigDecimal.ZERO)
+                .member(member)
+                .build()
+        );
+
+    ArgumentCaptor<Product> productCaptor = ArgumentCaptor.forClass(Product.class);
+
+    // when
+    ProductDto.Response savedProduct =
+        productServiceImplement.createProduct("testUser", "token", request);
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+    verify(memberService, times(1))
+        .getMemberByMemberId(eq("testUser"));
+    verify(productRepository, times(1)).save(productCaptor.capture());
+
+    assertThat(productCaptor.getValue()).isNotNull();
+    assertThat(productCaptor.getValue().getProductName()).isEqualTo("testProductName");
+    assertThat(productCaptor.getValue().getDescription()).isEqualTo("testProductDescription");
+    assertThat(productCaptor.getValue().getStockQuantity()).isEqualTo(3);
+    assertThat(productCaptor.getValue().getPrice()).isEqualTo(BigDecimal.valueOf(10000.0));
+    assertThat(productCaptor.getValue().getStatus()).isEqualTo(ProductStatus.IN_STOCK);
+    assertThat(productCaptor.getValue().getRating()).isEqualTo(BigDecimal.ZERO);
+    assertThat(productCaptor.getValue().getMember()).isEqualTo(member);
+  }
+
+  @Test
+  @DisplayName("상품 등록 - 실패 (토큰에 있는 멤버 정보와 불일치)")
+  void testCreateProduct_Fail_MemberUnMatched() {
+    // given
+    ProductDto.Request request = ProductDto.Request.builder()
+        .productName("testProductName")
+        .description("testProductDescription")
+        .stockQuantity(3)
+        .price(BigDecimal.valueOf(10000))
+        .status(ProductStatus.IN_STOCK)
+        .build();
+
+    doThrow(new MemberException(ResponseCode.MEMBER_UNMATCHED))
+        .when(authService).equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    // when
+    MemberException memberException = assertThrows(MemberException.class,
+        () -> productServiceImplement.createProduct("testUser", "token", request));
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    assertThat(memberException.getErrorCode()).isEqualTo(ResponseCode.MEMBER_UNMATCHED);
+  }
+
+  @Test
+  @DisplayName("상품 등록 - 실패 (존재하지 않는 멤버)")
+  void testCreateProduct_Fail_MemberNotFound() {
+    // given
+    ProductDto.Request request = ProductDto.Request.builder()
+        .productName("testProductName")
+        .description("testProductDescription")
+        .stockQuantity(3)
+        .price(BigDecimal.valueOf(10000))
+        .status(ProductStatus.IN_STOCK)
+        .build();
+
+    willDoNothing().given(authService)
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    doThrow(new MemberException(ResponseCode.MEMBER_NOT_FOUND))
+        .when(memberService).getMemberByMemberId(eq("testUser"));
+
+    // when
+    MemberException memberException = assertThrows(MemberException.class,
+        () -> productServiceImplement.createProduct("testUser", "token", request));
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+    verify(memberService, times(1))
+        .getMemberByMemberId(eq("testUser"));
+
+    assertThat(memberException.getErrorCode()).isEqualTo(ResponseCode.MEMBER_NOT_FOUND);
+  }
+
+}

--- a/src/test/java/com/ecommerce/service/product/ProductServiceImplementTest.java
+++ b/src/test/java/com/ecommerce/service/product/ProductServiceImplementTest.java
@@ -388,4 +388,269 @@ class ProductServiceImplementTest {
     assertThat(productList.getSize()).isEqualTo(0);
   }
 
+  @Test
+  @DisplayName("특정 판매자 상품 목록 조회 - 성공 (상품 상태 X)")
+  void testGetProductListByMemberId_Success_ProductStatusIsNull() {
+    // given
+    Sort sort = Sort.by(Direction.DESC, "createdAt");
+    Pageable pageable = PageRequest.of(0, TEST_PAGE_SIZE, sort);
+
+    Member member = Member.builder()
+        .memberId("testUser")
+        .memberName("test")
+        .email("test@email.com")
+        .password("encodedPassword")
+        .phoneNumber("01011112222")
+        .address("test시 test구 test로 111")
+        .role(Role.SELLER)
+        .loginType(LoginType.APP)
+        .build();
+
+    List<Product> mockProducts = List.of(
+        Product.builder()
+            .productName("testProductName1")
+            .description("testProductDescription1")
+            .stockQuantity(3)
+            .price(BigDecimal.valueOf(10001.0))
+            .status(ProductStatus.IN_STOCK)
+            .rating(BigDecimal.ZERO)
+            .member(member)
+            .build(),
+        Product.builder()
+            .productName("testProductName2")
+            .description("testProductDescription2")
+            .stockQuantity(3)
+            .price(BigDecimal.valueOf(10002.0))
+            .status(ProductStatus.IN_STOCK)
+            .rating(BigDecimal.ZERO)
+            .member(member)
+            .build(),
+        Product.builder()
+            .productName("testProductName3")
+            .description("testProductDescription3")
+            .stockQuantity(3)
+            .price(BigDecimal.valueOf(10003.0))
+            .status(ProductStatus.IN_STOCK)
+            .rating(BigDecimal.ZERO)
+            .member(member)
+            .build(),
+        Product.builder()
+            .productName("testProductName4")
+            .description("testProductDescription4")
+            .stockQuantity(3)
+            .price(BigDecimal.valueOf(10004.0))
+            .status(ProductStatus.IN_STOCK)
+            .rating(BigDecimal.ZERO)
+            .member(member)
+            .build(),
+        Product.builder()
+            .productName("testProductName5")
+            .description("testProductDescription5")
+            .stockQuantity(3)
+            .price(BigDecimal.valueOf(10005.0))
+            .status(ProductStatus.IN_STOCK)
+            .rating(BigDecimal.ZERO)
+            .member(member)
+            .build()
+    );
+
+    Page<Product> products = new PageImpl<>(mockProducts);
+
+    given(memberService.getMemberByMemberId(eq("testUser"))).willReturn(member);
+    given(
+        productRepository.findByMemberAndProductNameContaining(
+            eq(member), eq("testProductName"), eq(pageable)
+        )
+    ).willReturn(products);
+
+    // when
+    Page<ProductDto.Response> productList =
+        productServiceImplement
+            .getProductListByMemberId(
+                "testUser", 1, "testProductName", ProductStatus.NONE, SortType.LATEST
+            );
+
+    // then
+    verify(memberService, times(1))
+        .getMemberByMemberId(eq("testUser"));
+    verify(productRepository, times(1))
+        .findByMemberAndProductNameContaining(
+            eq(member), eq("testProductName"), eq(pageable)
+        );
+
+    assertThat(productList).isNotNull();
+    assertThat(productList.getSize()).isEqualTo(5);
+    for (ProductDto.Response response : productList.getContent()) {
+      assertThat(response.getSeller()).isEqualTo("testUser");
+    }
+  }
+
+  @Test
+  @DisplayName("특정 판매자 상품 목록 조회 - 성공 (상품 상태 O)")
+  void testGetProductListByMemberId_Success_ProductStatus() {
+    // given
+    Sort sort = Sort.by(Direction.DESC, "createdAt");
+    Pageable pageable = PageRequest.of(0, TEST_PAGE_SIZE, sort);
+
+    Member member = Member.builder()
+        .memberId("testUser")
+        .memberName("test")
+        .email("test@email.com")
+        .password("encodedPassword")
+        .phoneNumber("01011112222")
+        .address("test시 test구 test로 111")
+        .role(Role.SELLER)
+        .loginType(LoginType.APP)
+        .build();
+
+    List<Product> mockProducts = List.of(
+        Product.builder()
+            .productName("testProductName1")
+            .description("testProductDescription1")
+            .stockQuantity(3)
+            .price(BigDecimal.valueOf(10001.0))
+            .status(ProductStatus.NO_STOCK)
+            .rating(BigDecimal.ZERO)
+            .member(member)
+            .build(),
+        Product.builder()
+            .productName("testProductName2")
+            .description("testProductDescription2")
+            .stockQuantity(3)
+            .price(BigDecimal.valueOf(10002.0))
+            .status(ProductStatus.NO_STOCK)
+            .rating(BigDecimal.ZERO)
+            .member(member)
+            .build(),
+        Product.builder()
+            .productName("testProductName3")
+            .description("testProductDescription3")
+            .stockQuantity(3)
+            .price(BigDecimal.valueOf(10003.0))
+            .status(ProductStatus.NO_STOCK)
+            .rating(BigDecimal.ZERO)
+            .member(member)
+            .build(),
+        Product.builder()
+            .productName("testProductName4")
+            .description("testProductDescription4")
+            .stockQuantity(3)
+            .price(BigDecimal.valueOf(10004.0))
+            .status(ProductStatus.NO_STOCK)
+            .rating(BigDecimal.ZERO)
+            .member(member)
+            .build(),
+        Product.builder()
+            .productName("testProductName5")
+            .description("testProductDescription5")
+            .stockQuantity(3)
+            .price(BigDecimal.valueOf(10005.0))
+            .status(ProductStatus.NO_STOCK)
+            .rating(BigDecimal.ZERO)
+            .member(member)
+            .build()
+    );
+
+    Page<Product> products = new PageImpl<>(mockProducts);
+
+    given(memberService.getMemberByMemberId(eq("testUser"))).willReturn(member);
+    given(
+        productRepository.findByMemberAndProductNameContainingAndStatus(
+            eq(member), eq("testProductName"), eq(ProductStatus.NO_STOCK), eq(pageable)
+        )
+    ).willReturn(products);
+
+    // when
+    Page<ProductDto.Response> productList =
+        productServiceImplement
+            .getProductListByMemberId(
+                "testUser", 1, "testProductName", ProductStatus.NO_STOCK, SortType.LATEST
+            );
+
+    // then
+    verify(memberService, times(1))
+        .getMemberByMemberId(eq("testUser"));
+    verify(productRepository, times(1))
+        .findByMemberAndProductNameContainingAndStatus(
+            eq(member), eq("testProductName"), eq(ProductStatus.NO_STOCK), eq(pageable)
+        );
+
+    assertThat(productList).isNotNull();
+    assertThat(productList.getSize()).isEqualTo(5);
+    for (ProductDto.Response response : productList.getContent()) {
+      assertThat(response.getStatus()).isEqualTo(ProductStatus.NO_STOCK);
+      assertThat(response.getSeller()).isEqualTo("testUser");
+    }
+  }
+
+  @Test
+  @DisplayName("특정 판매자 상품 목록 조회 - 해당 결과 값 없음")
+  void testGetProductListByMemberId_NoResult() {
+    // given
+    Sort sort = Sort.by(Direction.DESC, "createdAt");
+    Pageable pageable = PageRequest.of(0, TEST_PAGE_SIZE, sort);
+
+    Member member = Member.builder()
+        .memberId("testUser")
+        .memberName("test")
+        .email("test@email.com")
+        .password("encodedPassword")
+        .phoneNumber("01011112222")
+        .address("test시 test구 test로 111")
+        .role(Role.SELLER)
+        .loginType(LoginType.APP)
+        .build();
+
+    List<Product> mockProducts = List.of();
+
+    Page<Product> products = new PageImpl<>(mockProducts);
+
+    given(memberService.getMemberByMemberId(eq("testUser")))
+        .willReturn(member);
+    given(
+        productRepository.findByMemberAndProductNameContainingAndStatus(
+            eq(member), eq("aaa"), eq(ProductStatus.NO_STOCK), eq(pageable)
+        )
+    ).willReturn(products);
+
+    // when
+    Page<ProductDto.Response> productList =
+        productServiceImplement
+            .getProductListByMemberId(
+                "testUser", 1, "aaa", ProductStatus.NO_STOCK, SortType.LATEST
+            );
+
+    // then
+    verify(memberService, times(1))
+        .getMemberByMemberId(eq("testUser"));
+    verify(productRepository, times(1))
+        .findByMemberAndProductNameContainingAndStatus(
+            eq(member), eq("aaa"), eq(ProductStatus.NO_STOCK), eq(pageable)
+        );
+
+    assertThat(productList).isNotNull();
+    assertThat(productList.getSize()).isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("특정 판매자 상품 목록 조회 - 실패 (존재하지 않는 멤버)")
+  void testGetProductListByMemberId_Fail_MemberNotFound() {
+    // given
+    doThrow(new MemberException(ResponseCode.MEMBER_NOT_FOUND))
+        .when(memberService).getMemberByMemberId(eq("testUser"));
+
+    // when
+    MemberException memberException = assertThrows(MemberException.class,
+        () -> productServiceImplement
+            .getProductListByMemberId(
+                "testUser", 1, "aaa", ProductStatus.NO_STOCK, SortType.LATEST
+            ));
+
+    // then
+    verify(memberService, times(1))
+        .getMemberByMemberId(eq("testUser"));
+
+    assertThat(memberException.getErrorCode()).isEqualTo(ResponseCode.MEMBER_NOT_FOUND);
+  }
+
 }

--- a/src/test/java/com/ecommerce/service/product/ProductServiceImplementTest.java
+++ b/src/test/java/com/ecommerce/service/product/ProductServiceImplementTest.java
@@ -21,7 +21,9 @@ import com.ecommerce.type.LoginType;
 import com.ecommerce.type.ProductStatus;
 import com.ecommerce.type.ResponseCode;
 import com.ecommerce.type.Role;
+import com.ecommerce.type.SortType;
 import java.math.BigDecimal;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,9 +31,17 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 
 @ExtendWith(MockitoExtension.class)
 class ProductServiceImplementTest {
+
+  private static final int TEST_PAGE_SIZE = 5;
 
   @Mock
   private AuthService authService;
@@ -165,6 +175,217 @@ class ProductServiceImplementTest {
         .getMemberByMemberId(eq("testUser"));
 
     assertThat(memberException.getErrorCode()).isEqualTo(ResponseCode.MEMBER_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("전체 상품 목록 조회 - 성공 (상품 상태 X)")
+  void testGetProductList_Success_ProductStatusIsNull() {
+    // given
+    Sort sort = Sort.by(Direction.DESC, "createdAt");
+    Pageable pageable = PageRequest.of(0, TEST_PAGE_SIZE, sort);
+
+    Member member = Member.builder()
+        .memberId("testUser")
+        .memberName("test")
+        .email("test@email.com")
+        .password("encodedPassword")
+        .phoneNumber("01011112222")
+        .address("test시 test구 test로 111")
+        .role(Role.SELLER)
+        .loginType(LoginType.APP)
+        .build();
+
+    List<Product> mockProducts = List.of(
+        Product.builder()
+            .productName("testProductName1")
+            .description("testProductDescription1")
+            .stockQuantity(3)
+            .price(BigDecimal.valueOf(10001.0))
+            .status(ProductStatus.IN_STOCK)
+            .rating(BigDecimal.ZERO)
+            .member(member)
+            .build(),
+        Product.builder()
+            .productName("testProductName2")
+            .description("testProductDescription2")
+            .stockQuantity(3)
+            .price(BigDecimal.valueOf(10002.0))
+            .status(ProductStatus.IN_STOCK)
+            .rating(BigDecimal.ZERO)
+            .member(member)
+            .build(),
+        Product.builder()
+            .productName("testProductName3")
+            .description("testProductDescription3")
+            .stockQuantity(3)
+            .price(BigDecimal.valueOf(10003.0))
+            .status(ProductStatus.IN_STOCK)
+            .rating(BigDecimal.ZERO)
+            .member(member)
+            .build(),
+        Product.builder()
+            .productName("testProductName4")
+            .description("testProductDescription4")
+            .stockQuantity(3)
+            .price(BigDecimal.valueOf(10004.0))
+            .status(ProductStatus.IN_STOCK)
+            .rating(BigDecimal.ZERO)
+            .member(member)
+            .build(),
+        Product.builder()
+            .productName("testProductName5")
+            .description("testProductDescription5")
+            .stockQuantity(3)
+            .price(BigDecimal.valueOf(10005.0))
+            .status(ProductStatus.IN_STOCK)
+            .rating(BigDecimal.ZERO)
+            .member(member)
+            .build()
+    );
+
+    Page<Product> products = new PageImpl<>(mockProducts);
+
+    given(
+        productRepository.findByProductNameContaining(
+            eq("testProductName"), eq(pageable)
+        )
+    ).willReturn(products);
+
+    // when
+    Page<ProductDto.Response> productList =
+        productServiceImplement
+            .getProductList(1, "testProductName", ProductStatus.NONE, SortType.LATEST);
+
+    // then
+    verify(productRepository, times(1))
+        .findByProductNameContaining(
+            eq("testProductName"), eq(pageable)
+        );
+
+    assertThat(productList).isNotNull();
+    assertThat(productList.getSize()).isEqualTo(5);
+  }
+
+  @Test
+  @DisplayName("전체 상품 목록 조회 - 성공 (상품 상태 O)")
+  void testGetProductList_Success_ProductStatus() {
+    // given
+    Sort sort = Sort.by(Direction.DESC, "createdAt");
+    Pageable pageable = PageRequest.of(0, TEST_PAGE_SIZE, sort);
+
+    Member member = Member.builder()
+        .memberId("testUser")
+        .memberName("test")
+        .email("test@email.com")
+        .password("encodedPassword")
+        .phoneNumber("01011112222")
+        .address("test시 test구 test로 111")
+        .role(Role.SELLER)
+        .loginType(LoginType.APP)
+        .build();
+
+    List<Product> mockProducts = List.of(
+        Product.builder()
+            .productName("testProductName1")
+            .description("testProductDescription1")
+            .stockQuantity(3)
+            .price(BigDecimal.valueOf(10001.0))
+            .status(ProductStatus.NO_STOCK)
+            .rating(BigDecimal.ZERO)
+            .member(member)
+            .build(),
+        Product.builder()
+            .productName("testProductName2")
+            .description("testProductDescription2")
+            .stockQuantity(3)
+            .price(BigDecimal.valueOf(10002.0))
+            .status(ProductStatus.NO_STOCK)
+            .rating(BigDecimal.ZERO)
+            .member(member)
+            .build(),
+        Product.builder()
+            .productName("testProductName3")
+            .description("testProductDescription3")
+            .stockQuantity(3)
+            .price(BigDecimal.valueOf(10003.0))
+            .status(ProductStatus.NO_STOCK)
+            .rating(BigDecimal.ZERO)
+            .member(member)
+            .build(),
+        Product.builder()
+            .productName("testProductName4")
+            .description("testProductDescription4")
+            .stockQuantity(3)
+            .price(BigDecimal.valueOf(10004.0))
+            .status(ProductStatus.NO_STOCK)
+            .rating(BigDecimal.ZERO)
+            .member(member)
+            .build(),
+        Product.builder()
+            .productName("testProductName5")
+            .description("testProductDescription5")
+            .stockQuantity(3)
+            .price(BigDecimal.valueOf(10005.0))
+            .status(ProductStatus.NO_STOCK)
+            .rating(BigDecimal.ZERO)
+            .member(member)
+            .build()
+    );
+
+    Page<Product> products = new PageImpl<>(mockProducts);
+
+    given(
+        productRepository.findByProductNameContainingAndStatus(
+            eq("testProductName"), eq(ProductStatus.NO_STOCK), eq(pageable)
+        )
+    ).willReturn(products);
+
+    // when
+    Page<ProductDto.Response> productList =
+        productServiceImplement
+            .getProductList(1, "testProductName", ProductStatus.NO_STOCK, SortType.LATEST);
+
+    // then
+    verify(productRepository, times(1))
+        .findByProductNameContainingAndStatus(
+            eq("testProductName"), eq(ProductStatus.NO_STOCK), eq(pageable)
+        );
+
+    assertThat(productList).isNotNull();
+    assertThat(productList.getSize()).isEqualTo(5);
+    assertThat(productList.getContent().get(0).getStatus()).isEqualTo(ProductStatus.NO_STOCK);
+  }
+
+  @Test
+  @DisplayName("전체 상품 목록 조회 - 해당 결과 값 없음")
+  void testGetProductList_NoResult() {
+    // given
+    Sort sort = Sort.by(Direction.DESC, "createdAt");
+    Pageable pageable = PageRequest.of(0, TEST_PAGE_SIZE, sort);
+
+    List<Product> mockProducts = List.of();
+
+    Page<Product> products = new PageImpl<>(mockProducts);
+
+    given(
+        productRepository.findByProductNameContainingAndStatus(
+            eq("aaa"), eq(ProductStatus.NO_STOCK), eq(pageable)
+        )
+    ).willReturn(products);
+
+    // when
+    Page<ProductDto.Response> productList =
+        productServiceImplement
+            .getProductList(1, "aaa", ProductStatus.NO_STOCK, SortType.LATEST);
+
+    // then
+    verify(productRepository, times(1))
+        .findByProductNameContainingAndStatus(
+            eq("aaa"), eq(ProductStatus.NO_STOCK), eq(pageable)
+        );
+
+    assertThat(productList).isNotNull();
+    assertThat(productList.getSize()).isEqualTo(0);
   }
 
 }

--- a/src/test/java/com/ecommerce/service/product/ProductServiceImplementTest.java
+++ b/src/test/java/com/ecommerce/service/product/ProductServiceImplementTest.java
@@ -657,6 +657,65 @@ class ProductServiceImplementTest {
   }
 
   @Test
+  @DisplayName("상품 정보 조회 - 성공")
+  void testGetProductDetails_Success() {
+    // given
+    Member member = Member.builder()
+        .memberId("testUser")
+        .memberName("test")
+        .email("test@email.com")
+        .password("encodedPassword")
+        .phoneNumber("01011112222")
+        .address("test시 test구 test로 111")
+        .role(Role.SELLER)
+        .loginType(LoginType.APP)
+        .build();
+
+    Product product = Product.builder()
+        .productName("testProductName")
+        .description("testProductDescription")
+        .stockQuantity(3)
+        .price(BigDecimal.valueOf(10001.0))
+        .status(ProductStatus.IN_STOCK)
+        .rating(BigDecimal.ZERO)
+        .member(member)
+        .build();
+
+    given(productRepository.findById(1L)).willReturn(Optional.ofNullable(product));
+
+    // when
+    ProductDto.Response productDetails = productServiceImplement.getProductDetails(1L);
+
+    // then
+    verify(productRepository, times(1))
+        .findById(eq(1L));
+
+    assertThat(productDetails.getProductName()).isEqualTo("testProductName");
+    assertThat(productDetails.getDescription()).isEqualTo("testProductDescription");
+    assertThat(productDetails.getStockQuantity()).isEqualTo(3);
+    assertThat(productDetails.getPrice()).isEqualTo(BigDecimal.valueOf(10001.0));
+    assertThat(productDetails.getStatus()).isEqualTo(ProductStatus.IN_STOCK);
+    assertThat(productDetails.getSeller()).isEqualTo(member.getMemberId());
+  }
+
+  @Test
+  @DisplayName("상품 정보 조회 - 실패")
+  void testGetProductDetails_Fail() {
+    // given
+    given(productRepository.findById(1L)).willReturn(Optional.empty());
+
+    // when
+    ProductException productException = assertThrows(ProductException.class,
+        () -> productServiceImplement.getProductDetails(1L));
+
+    // then
+    verify(productRepository, times(1))
+        .findById(eq(1L));
+
+    assertThat(productException.getErrorCode()).isEqualTo(ResponseCode.PRODUCT_NOT_FOUND);
+  }
+
+  @Test
   @DisplayName("상품 정보 수정 - 성공")
   void testUpdateProduct_Success() {
     // given
@@ -680,8 +739,8 @@ class ProductServiceImplementTest {
         .build();
 
     Product product = Product.builder()
-        .productName("testProductName1")
-        .description("testProductDescription1")
+        .productName("testProductName")
+        .description("testProductDescription")
         .stockQuantity(3)
         .price(BigDecimal.valueOf(10001.0))
         .status(ProductStatus.NO_STOCK)
@@ -718,7 +777,6 @@ class ProductServiceImplementTest {
         .build();
 
     given(productRepository.findById(1L)).willReturn(Optional.empty());
-
 
     // when
     ProductException productException = assertThrows(ProductException.class,


### PR DESCRIPTION
### Pull Request

> ### 제목
>
> - Fix: Builder.Default 를 활용해 ProductStatus 초기값 설정
> - Test: 상품 등록, 조회, 수정, 삭제 테스트 코드작성

> ### 변경사항
> 
> 📌 **AS-IS**
> - 상품 등록, 수정, 삭제 기능 구현
> - 멤버 정보 조회시 Self-Invocation 문제 발생 수정
> - 회원 정보 조회, 수정, 삭제 시 요청으로 들어온 Path Variable 의 memberId 와 헤더값의 토큰 에있는 memberId 값을 비교
> - 전체 상품 목록 조회 및 특정 판매자 상품 목록 조회 기능 구현
>
> 🔖 **TO-BE**
> 🔧 Builder.Default 를 활용해 ProductStatus 초기값 설정
> - 기존 API Test 할 때는 Builder.Default 없이도 ProductStatus 초기값이 설정되어 저장이 되었는데
>    단위테스트시 ProductDto.Request 클래스의 객체를 모킹하려 임의의 객체를 생성할 때
>    Builder 어노테이션을 사용 하는경우 ProductDto.Request 클래스의 status 필드에 초기 값을 직접
>    할당하면 Builder 가 이를 무시하기 때문에 status 필드의 기본값을 ProductStatus.IN_STOCK 으로 지정했지만
>    Builder 를 사용해 객체를 생성할 때는 이 기본값이 적용되지 않는 이슈가 발생해 Builder.Default 어노테이션을
>    사용하여 해결
>
> 🔧 상품 등록, 조회, 수정, 삭제 테스트  코드 작성
> - 각 기능 실행시 발생할 수 있는 성공 및 실패 케이스에 대한 테스트 코드 작성

> ### 테스트
>
> - [x] 테스트 코드
> - [x] API 테스트