### PR TITLE
Feature/cart

### DIFF
--- a/src/main/java/com/ecommerce/controller/CartController.java
+++ b/src/main/java/com/ecommerce/controller/CartController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @PreAuthorize("hasRole('ROLE_CUSTOMER')")
-@RequestMapping("/api/v1/carts/customer")
+@RequestMapping("/api/v1/carts/customer/{memberId}/cart-items")
 @RequiredArgsConstructor
 public class CartController {
 
@@ -35,7 +35,7 @@ public class CartController {
    * @param token
    * @return CartDto
    */
-  @GetMapping("/{memberId}")
+  @GetMapping
   public CartDto getCartDetails(
       @PathVariable String memberId,
       @RequestHeader("Authorization") String token
@@ -51,7 +51,7 @@ public class CartController {
    * @param request
    * @return CartItemDto.Response
    */
-  @PostMapping("/{memberId}/cart-item")
+  @PostMapping
   public CartItemDto.Response addCartItem(
       @PathVariable String memberId,
       @RequestHeader("Authorization") String token,
@@ -69,7 +69,7 @@ public class CartController {
    * @param updateRequest
    * @return CartItemDto.Response
    */
-  @PutMapping("/{memberId}/cart-item/{cartItemId}")
+  @PutMapping("/{cartItemId}")
   public CartItemDto.Response updateCartItem(
       @PathVariable String memberId,
       @PathVariable Long cartItemId,
@@ -87,7 +87,7 @@ public class CartController {
    * @param token
    * @return ResponseDto
    */
-  @DeleteMapping("/{memberId}/cart-item/{cartItemId}")
+  @DeleteMapping("/{cartItemId}")
   public ResponseDto deleteCartItem(
       @PathVariable String memberId,
       @PathVariable Long cartItemId,
@@ -103,7 +103,7 @@ public class CartController {
    * @param token
    * @return ResponseDto
    */
-  @DeleteMapping("/{memberId}/cart-item")
+  @DeleteMapping
   public ResponseDto deleteAllCartItem(
       @PathVariable String memberId,
       @RequestHeader("Authorization") String token

--- a/src/main/java/com/ecommerce/controller/CartController.java
+++ b/src/main/java/com/ecommerce/controller/CartController.java
@@ -1,5 +1,6 @@
 package com.ecommerce.controller;
 
+import com.ecommerce.dto.ResponseDto;
 import com.ecommerce.dto.cart.CartDto;
 import com.ecommerce.dto.cart.CartItemDto;
 import com.ecommerce.dto.cart.UpdateCartItemDto;
@@ -8,6 +9,7 @@ import com.ecommerce.service.cart.CartService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -62,6 +64,7 @@ public class CartController {
    * 장바구니 상품 수량 수정
    *
    * @param memberId
+   * @param cartItemId
    * @param token
    * @param updateRequest
    * @return CartItemDto.Response
@@ -74,6 +77,23 @@ public class CartController {
       @RequestBody @Valid UpdateCartItemDto updateRequest
   ) {
     return cartItemService.updateCartItem(memberId, cartItemId, token, updateRequest);
+  }
+
+  /**
+   * 장바구니 상품 삭제
+   *
+   * @param memberId
+   * @param cartItemId
+   * @param token
+   * @return ResponseDto
+   */
+  @DeleteMapping("/{memberId}/cart-item/{cartItemId}")
+  public ResponseDto deleteCartItem(
+      @PathVariable String memberId,
+      @PathVariable Long cartItemId,
+      @RequestHeader("Authorization") String token
+  ) {
+    return cartItemService.deleteCartItem(memberId, cartItemId, token);
   }
 
 }

--- a/src/main/java/com/ecommerce/controller/CartController.java
+++ b/src/main/java/com/ecommerce/controller/CartController.java
@@ -1,6 +1,5 @@
 package com.ecommerce.controller;
 
-import com.ecommerce.dto.ResponseDto;
 import com.ecommerce.dto.cart.CartDto;
 import com.ecommerce.dto.cart.CartItemDto;
 import com.ecommerce.service.cart.CartItemService;

--- a/src/main/java/com/ecommerce/controller/CartController.java
+++ b/src/main/java/com/ecommerce/controller/CartController.java
@@ -49,7 +49,7 @@ public class CartController {
    * @return ResponseDto
    */
   @PostMapping("/{memberId}/cart-item")
-  public ResponseDto addCartItem(
+  public CartItemDto.Response addCartItem(
       @PathVariable String memberId,
       @RequestHeader("Authorization") String token,
       @RequestBody @Valid CartItemDto.Request request

--- a/src/main/java/com/ecommerce/controller/CartController.java
+++ b/src/main/java/com/ecommerce/controller/CartController.java
@@ -2,6 +2,7 @@ package com.ecommerce.controller;
 
 import com.ecommerce.dto.cart.CartDto;
 import com.ecommerce.dto.cart.CartItemDto;
+import com.ecommerce.dto.cart.UpdateCartItemDto;
 import com.ecommerce.service.cart.CartItemService;
 import com.ecommerce.service.cart.CartService;
 import jakarta.validation.Valid;
@@ -10,6 +11,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -45,7 +47,7 @@ public class CartController {
    * @param memberId
    * @param token
    * @param request
-   * @return ResponseDto
+   * @return CartItemDto.Response
    */
   @PostMapping("/{memberId}/cart-item")
   public CartItemDto.Response addCartItem(
@@ -54,6 +56,24 @@ public class CartController {
       @RequestBody @Valid CartItemDto.Request request
   ) {
     return cartItemService.addCartItem(memberId, token, request);
+  }
+
+  /**
+   * 장바구니 상품 수량 수정
+   *
+   * @param memberId
+   * @param token
+   * @param updateRequest
+   * @return CartItemDto.Response
+   */
+  @PutMapping("/{memberId}/cart-item/{cartItemId}")
+  public CartItemDto.Response updateCartItem(
+      @PathVariable String memberId,
+      @PathVariable Long cartItemId,
+      @RequestHeader("Authorization") String token,
+      @RequestBody @Valid UpdateCartItemDto updateRequest
+  ) {
+    return cartItemService.updateCartItem(memberId, cartItemId, token, updateRequest);
   }
 
 }

--- a/src/main/java/com/ecommerce/controller/CartController.java
+++ b/src/main/java/com/ecommerce/controller/CartController.java
@@ -96,4 +96,19 @@ public class CartController {
     return cartItemService.deleteCartItem(memberId, cartItemId, token);
   }
 
+  /**
+   * 장바구니 상품 전체 삭제
+   *
+   * @param memberId
+   * @param token
+   * @return ResponseDto
+   */
+  @DeleteMapping("/{memberId}/cart-item")
+  public ResponseDto deleteAllCartItem(
+      @PathVariable String memberId,
+      @RequestHeader("Authorization") String token
+  ) {
+    return cartItemService.deleteAllCartItem(memberId, token);
+  }
+
 }

--- a/src/main/java/com/ecommerce/controller/CartController.java
+++ b/src/main/java/com/ecommerce/controller/CartController.java
@@ -27,6 +27,7 @@ public class CartController {
 
   /**
    * 특정 유저의 장바구니 목록 조회
+   *
    * @param memberId
    * @param token
    * @return CartDto
@@ -41,6 +42,7 @@ public class CartController {
 
   /**
    * 장바구니에 상품 담기
+   *
    * @param memberId
    * @param token
    * @param request

--- a/src/main/java/com/ecommerce/controller/CartController.java
+++ b/src/main/java/com/ecommerce/controller/CartController.java
@@ -1,18 +1,29 @@
 package com.ecommerce.controller;
 
+import com.ecommerce.dto.ResponseDto;
 import com.ecommerce.dto.cart.CartDto;
+import com.ecommerce.dto.cart.CartItemDto;
+import com.ecommerce.service.cart.CartItemService;
 import com.ecommerce.service.cart.CartService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@PreAuthorize("hasRole('ROLE_CUSTOMER')")
+@RequestMapping("/api/v1/carts/customer")
 @RequiredArgsConstructor
 public class CartController {
 
   private final CartService cartService;
+  private final CartItemService cartItemService;
 
   /**
    * 특정 유저의 장바구니 목록 조회
@@ -26,6 +37,22 @@ public class CartController {
       @RequestHeader("Authorization") String token
   ) {
     return cartService.getCartDetails(memberId, token);
+  }
+
+  /**
+   * 장바구니에 상품 담기
+   * @param memberId
+   * @param token
+   * @param request
+   * @return ResponseDto
+   */
+  @PostMapping("/{memberId}/cart-item")
+  public ResponseDto addCartItem(
+      @PathVariable String memberId,
+      @RequestHeader("Authorization") String token,
+      @RequestBody @Valid CartItemDto.Request request
+  ) {
+    return cartItemService.addCartItem(memberId, token, request);
   }
 
 }

--- a/src/main/java/com/ecommerce/controller/CartController.java
+++ b/src/main/java/com/ecommerce/controller/CartController.java
@@ -1,0 +1,31 @@
+package com.ecommerce.controller;
+
+import com.ecommerce.dto.cart.CartDto;
+import com.ecommerce.service.cart.CartService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class CartController {
+
+  private final CartService cartService;
+
+  /**
+   * 특정 유저의 장바구니 목록 조회
+   * @param memberId
+   * @param token
+   * @return CartDto
+   */
+  @GetMapping("/{memberId}")
+  public CartDto getCartDetails(
+      @PathVariable String memberId,
+      @RequestHeader("Authorization") String token
+  ) {
+    return cartService.getCartDetails(memberId, token);
+  }
+
+}

--- a/src/main/java/com/ecommerce/dto/cart/CartDto.java
+++ b/src/main/java/com/ecommerce/dto/cart/CartDto.java
@@ -1,0 +1,41 @@
+package com.ecommerce.dto.cart;
+
+import com.ecommerce.entity.Cart;
+import java.math.BigDecimal;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CartDto {
+
+  private String memberId;
+  private BigDecimal totalPrice;
+  private List<CartItemDto.Response> cartItems;
+
+  public static CartDto fromEntity(Cart cart) {
+
+    List<CartItemDto.Response> cartItems = cart.getCartItems().stream()
+        .map(CartItemDto.Response::fromEntity)
+        .toList();
+
+    BigDecimal totalPrice = cartItems.stream()
+        .map(CartItemDto.Response::getPrice)
+        .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+    return CartDto.builder()
+        .memberId(cart.getMember().getMemberId())
+        .totalPrice(totalPrice)
+        .cartItems(cartItems)
+        .build();
+
+  }
+
+}

--- a/src/main/java/com/ecommerce/dto/cart/CartItemDto.java
+++ b/src/main/java/com/ecommerce/dto/cart/CartItemDto.java
@@ -1,0 +1,65 @@
+package com.ecommerce.dto.cart;
+
+import com.ecommerce.entity.CartItem;
+import com.ecommerce.type.ProductStatus;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class CartItemDto {
+
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public static class Request {
+
+    @NotNull
+    private Long productId;
+
+    @NotNull
+    @Min(value = 1)
+    private Integer quantity;
+
+  }
+
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public static class Response {
+
+    private Long id;
+    private Long cartId;
+    private Long productId;
+    private String productName;
+    private Integer quantity;
+    private BigDecimal price;
+    private ProductStatus status;
+
+    public static Response fromEntity(CartItem cartItem) {
+      return Response.builder()
+          .id(cartItem.getId())
+          .cartId(cartItem.getCart().getId())
+          .productId(cartItem.getProduct().getId())
+          .productName(cartItem.getProduct().getProductName())
+          .quantity(cartItem.getQuantity())
+          .price(
+              BigDecimal.valueOf(cartItem.getQuantity())
+                  .multiply(cartItem.getProduct().getPrice())
+          )
+          .status(cartItem.getProduct().getStatus())
+          .build();
+    }
+
+
+  }
+
+}

--- a/src/main/java/com/ecommerce/dto/cart/CartItemDto.java
+++ b/src/main/java/com/ecommerce/dto/cart/CartItemDto.java
@@ -59,7 +59,6 @@ public class CartItemDto {
           .build();
     }
 
-
   }
 
 }

--- a/src/main/java/com/ecommerce/dto/cart/UpdateCartItemDto.java
+++ b/src/main/java/com/ecommerce/dto/cart/UpdateCartItemDto.java
@@ -1,0 +1,22 @@
+package com.ecommerce.dto.cart;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Getter
+@Service
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateCartItemDto {
+
+  @NotNull
+  @Min(value = 1)
+  private Integer quantity;
+
+}

--- a/src/main/java/com/ecommerce/entity/Cart.java
+++ b/src/main/java/com/ecommerce/entity/Cart.java
@@ -1,0 +1,31 @@
+package com.ecommerce.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class Cart extends BaseEntity {
+
+  @ManyToOne
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
+
+  @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<CartItem> cartItems = new ArrayList<>();
+
+}

--- a/src/main/java/com/ecommerce/entity/CartItem.java
+++ b/src/main/java/com/ecommerce/entity/CartItem.java
@@ -1,0 +1,40 @@
+package com.ecommerce.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class CartItem extends BaseEntity {
+
+  @ManyToOne
+  @JoinColumn(name = "cart_id", nullable = false)
+  private Cart cart;
+
+  @ManyToOne
+  @JoinColumn(name = "product_id", nullable = false)
+  private Product product;
+
+  @Min(value = 1)
+  @Column(nullable = false)
+  private Integer quantity;
+
+  @DecimalMin(value = "0.0", inclusive = false)
+  @Column(nullable = false)
+  private BigDecimal price;
+
+}

--- a/src/main/java/com/ecommerce/exception/CartException.java
+++ b/src/main/java/com/ecommerce/exception/CartException.java
@@ -1,0 +1,17 @@
+package com.ecommerce.exception;
+
+import com.ecommerce.type.ResponseCode;
+import lombok.Getter;
+
+@Getter
+public class CartException extends RuntimeException {
+
+  private final ResponseCode errorCode;
+  private final String errorMessage;
+
+  public CartException(ResponseCode errorCode) {
+    this.errorCode = errorCode;
+    this.errorMessage = errorCode.getDescription();
+  }
+
+}

--- a/src/main/java/com/ecommerce/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/ecommerce/exception/handler/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.ecommerce.exception.handler;
 
 import com.ecommerce.dto.ResponseDto;
+import com.ecommerce.exception.CartException;
 import com.ecommerce.exception.CertificationException;
 import com.ecommerce.exception.DataBaseException;
 import com.ecommerce.exception.EmailException;
@@ -59,6 +60,13 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(ProductException.class)
   public ResponseEntity<ResponseDto> productExceptionHandler(ProductException e) {
     log.error("{} 에러가 발생했습니다. (product)", e.getErrorCode());
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(ResponseDto.getResponseBody(e.getErrorCode()));
+  }
+
+  @ExceptionHandler(CartException.class)
+  public ResponseEntity<ResponseDto> cartExceptionHandler(CartException e) {
+    log.error("{} 에러가 발생했습니다. (cart)", e.getErrorCode());
     return ResponseEntity.status(HttpStatus.BAD_REQUEST)
         .body(ResponseDto.getResponseBody(e.getErrorCode()));
   }

--- a/src/main/java/com/ecommerce/repository/CartItemRepository.java
+++ b/src/main/java/com/ecommerce/repository/CartItemRepository.java
@@ -3,11 +3,12 @@ package com.ecommerce.repository;
 import com.ecommerce.entity.Cart;
 import com.ecommerce.entity.CartItem;
 import com.ecommerce.entity.Product;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CartItemRepository extends JpaRepository<CartItem, Long> {
 
-  boolean existsByCartAndProduct(Cart cart, Product product);
+  Optional<CartItem> findByCartAndProduct(Cart cart, Product product);
 
   void deleteAllByCart(Cart cart);
 

--- a/src/main/java/com/ecommerce/repository/CartItemRepository.java
+++ b/src/main/java/com/ecommerce/repository/CartItemRepository.java
@@ -1,0 +1,12 @@
+package com.ecommerce.repository;
+
+import com.ecommerce.entity.Cart;
+import com.ecommerce.entity.CartItem;
+import com.ecommerce.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+
+  boolean existsByCartAndProduct(Cart cart, Product product);
+
+}

--- a/src/main/java/com/ecommerce/repository/CartItemRepository.java
+++ b/src/main/java/com/ecommerce/repository/CartItemRepository.java
@@ -9,4 +9,6 @@ public interface CartItemRepository extends JpaRepository<CartItem, Long> {
 
   boolean existsByCartAndProduct(Cart cart, Product product);
 
+  void deleteAllByCart(Cart cart);
+
 }

--- a/src/main/java/com/ecommerce/repository/CartRepository.java
+++ b/src/main/java/com/ecommerce/repository/CartRepository.java
@@ -1,0 +1,14 @@
+package com.ecommerce.repository;
+
+import com.ecommerce.entity.Cart;
+import com.ecommerce.entity.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CartRepository extends JpaRepository<Cart,Long> {
+
+  Optional<Cart> findByMember(Member member);
+
+  boolean existsByMember(Member member);
+
+}

--- a/src/main/java/com/ecommerce/service/auth/AuthServiceImplement.java
+++ b/src/main/java/com/ecommerce/service/auth/AuthServiceImplement.java
@@ -54,7 +54,7 @@ public class AuthServiceImplement implements AuthService {
 
     checkExistsUserId(request.getMemberId());
 
-    return ResponseDto.getResponseBody(ResponseCode.AVAILABLE_USER_ID);
+    return ResponseDto.getResponseBody(ResponseCode.MEMBER_ID_AVAILABLE);
 
   }
 
@@ -122,7 +122,7 @@ public class AuthServiceImplement implements AuthService {
 
     boolean isCheckVerified = redisService.checkVerified(userId + ":verified");
     if (!isCheckVerified) {
-      throw new CertificationException(ResponseCode.DOSE_NOT_EXISTS_CERTIFICATION);
+      throw new CertificationException(ResponseCode.MAIL_CERTIFICATION_DOSE_NOT_EXISTS);
     }
 
     try {
@@ -158,7 +158,7 @@ public class AuthServiceImplement implements AuthService {
 
     boolean isMatched = passwordEncoder.matches(request.getPassword(), member.getPassword());
     if (!isMatched) {
-      throw new MemberException(ResponseCode.PASSWORD_UNMATCHED);
+      throw new MemberException(ResponseCode.MEMBER_PASSWORD_UNMATCHED);
     }
 
     String token = jwtProvider.createToken(member.getMemberId(), member.getRole());

--- a/src/main/java/com/ecommerce/service/auth/OAuth2MemberServiceImplement.java
+++ b/src/main/java/com/ecommerce/service/auth/OAuth2MemberServiceImplement.java
@@ -2,8 +2,10 @@ package com.ecommerce.service.auth;
 
 import com.ecommerce.dto.auth.KakaoUserInfoDto.KakaoResponse;
 import com.ecommerce.dto.auth.NaverUserInfoDto.NaverResponse;
+import com.ecommerce.entity.Cart;
 import com.ecommerce.entity.CustomOAuth2Member;
 import com.ecommerce.entity.Member;
+import com.ecommerce.repository.CartRepository;
 import com.ecommerce.repository.MemberRepository;
 import com.ecommerce.type.LoginType;
 import com.ecommerce.type.ResponseCode;
@@ -15,32 +17,41 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class OAuth2MemberServiceImplement extends DefaultOAuth2UserService {
 
   private final MemberRepository memberRepository;
+  private final CartRepository cartRepository;
   private final ObjectMapper objectMapper;
 
   /**
    * OAuth Server 에 요청을 보낸 후 redirect 로 각 소셜 로그인으로 로그인한 유저의 정보를 받아 Ecommerce Application DB 에 저장후
-   * Ecommerce Application 의 토큰 생성을 위해 CustomOAuth2Member 객체로 반환
+   * 저장된 유저의 정보로 장바구니 생성, Ecommerce Application 의 토큰 생성을 위해 CustomOAuth2Member 객체로 반환
    *
    * @param request
    * @return CustomOAuth2Member
    * @throws OAuth2AuthenticationException
    */
   @Override
+  @Transactional
   public OAuth2User loadUser(OAuth2UserRequest request) throws OAuth2AuthenticationException {
 
     OAuth2User oAuth2User = super.loadUser(request);
     String oauthClientName = request.getClientRegistration().getClientName();
 
     Member member = createSnsMember(oauthClientName, oAuth2User);
-    ;
 
-    memberRepository.save(member);
+    Member savedMember = memberRepository.save(member);
+
+    boolean isExists = cartRepository.existsByMember(savedMember);
+    if (!isExists) {
+      cartRepository.save(
+          Cart.builder().member(savedMember).build()
+      );
+    }
 
     return new CustomOAuth2Member(member.getMemberId());
 

--- a/src/main/java/com/ecommerce/service/cart/CartItemService.java
+++ b/src/main/java/com/ecommerce/service/cart/CartItemService.java
@@ -3,6 +3,7 @@ package com.ecommerce.service.cart;
 import com.ecommerce.dto.ResponseDto;
 import com.ecommerce.dto.cart.CartItemDto;
 import com.ecommerce.dto.cart.UpdateCartItemDto;
+import com.ecommerce.entity.CartItem;
 
 public interface CartItemService {
 
@@ -10,8 +11,12 @@ public interface CartItemService {
 
   CartItemDto.Response updateCartItem(String memberId, Long cartItemId, String token, UpdateCartItemDto updateRequest);
 
+  void checkExceedStockQuantity(int totalQuantity, int stockQuantity);
+
   ResponseDto deleteCartItem(String memberId, Long cartItemId, String token);
 
   ResponseDto deleteAllCartItem(String memberId, String token);
+
+  CartItem getCartItemById(Long cartItemId);
 
 }

--- a/src/main/java/com/ecommerce/service/cart/CartItemService.java
+++ b/src/main/java/com/ecommerce/service/cart/CartItemService.java
@@ -1,9 +1,12 @@
 package com.ecommerce.service.cart;
 
 import com.ecommerce.dto.cart.CartItemDto;
+import com.ecommerce.dto.cart.UpdateCartItemDto;
 
 public interface CartItemService {
 
   CartItemDto.Response addCartItem(String memberId, String token, CartItemDto.Request request);
+
+  CartItemDto.Response updateCartItem(String memberId, Long cartItemId, String token, UpdateCartItemDto updateRequest);
 
 }

--- a/src/main/java/com/ecommerce/service/cart/CartItemService.java
+++ b/src/main/java/com/ecommerce/service/cart/CartItemService.java
@@ -1,10 +1,9 @@
 package com.ecommerce.service.cart;
 
-import com.ecommerce.dto.ResponseDto;
 import com.ecommerce.dto.cart.CartItemDto;
 
 public interface CartItemService {
 
-  ResponseDto addCartItem(String memberId, String token, CartItemDto.Request request);
+  CartItemDto.Response addCartItem(String memberId, String token, CartItemDto.Request request);
 
 }

--- a/src/main/java/com/ecommerce/service/cart/CartItemService.java
+++ b/src/main/java/com/ecommerce/service/cart/CartItemService.java
@@ -12,4 +12,6 @@ public interface CartItemService {
 
   ResponseDto deleteCartItem(String memberId, Long cartItemId, String token);
 
+  ResponseDto deleteAllCartItem(String memberId, String token);
+
 }

--- a/src/main/java/com/ecommerce/service/cart/CartItemService.java
+++ b/src/main/java/com/ecommerce/service/cart/CartItemService.java
@@ -1,5 +1,6 @@
 package com.ecommerce.service.cart;
 
+import com.ecommerce.dto.ResponseDto;
 import com.ecommerce.dto.cart.CartItemDto;
 import com.ecommerce.dto.cart.UpdateCartItemDto;
 
@@ -8,5 +9,7 @@ public interface CartItemService {
   CartItemDto.Response addCartItem(String memberId, String token, CartItemDto.Request request);
 
   CartItemDto.Response updateCartItem(String memberId, Long cartItemId, String token, UpdateCartItemDto updateRequest);
+
+  ResponseDto deleteCartItem(String memberId, Long cartItemId, String token);
 
 }

--- a/src/main/java/com/ecommerce/service/cart/CartItemService.java
+++ b/src/main/java/com/ecommerce/service/cart/CartItemService.java
@@ -1,0 +1,10 @@
+package com.ecommerce.service.cart;
+
+import com.ecommerce.dto.ResponseDto;
+import com.ecommerce.dto.cart.CartItemDto;
+
+public interface CartItemService {
+
+  ResponseDto addCartItem(String memberId, String token, CartItemDto.Request request);
+
+}

--- a/src/main/java/com/ecommerce/service/cart/CartItemServiceImplement.java
+++ b/src/main/java/com/ecommerce/service/cart/CartItemServiceImplement.java
@@ -1,6 +1,5 @@
 package com.ecommerce.service.cart;
 
-import com.ecommerce.dto.ResponseDto;
 import com.ecommerce.dto.cart.CartItemDto;
 import com.ecommerce.entity.Cart;
 import com.ecommerce.entity.CartItem;
@@ -39,7 +38,8 @@ public class CartItemServiceImplement implements CartItemService {
    */
   @Override
   @Transactional
-  public ResponseDto addCartItem(String memberId, String token, CartItemDto.Request request) {
+  public CartItemDto.Response addCartItem(String memberId, String token,
+      CartItemDto.Request request) {
 
     authService.equalToMemberIdFromToken(memberId, token);
 
@@ -56,16 +56,16 @@ public class CartItemServiceImplement implements CartItemService {
       throw new CartException(ResponseCode.CART_ITEM_ALREADY_EXISTS);
     }
 
-    cartItemRepository.save(
-        CartItem.builder()
-            .cart(cart)
-            .product(product)
-            .quantity(request.getQuantity())
-            .price(product.getPrice())
-            .build()
+    return CartItemDto.Response.fromEntity(
+        cartItemRepository.save(
+            CartItem.builder()
+                .cart(cart)
+                .product(product)
+                .quantity(request.getQuantity())
+                .price(product.getPrice())
+                .build()
+        )
     );
-
-    return ResponseDto.getResponseBody(ResponseCode.ADDED_CART_ITEM);
 
   }
 

--- a/src/main/java/com/ecommerce/service/cart/CartItemServiceImplement.java
+++ b/src/main/java/com/ecommerce/service/cart/CartItemServiceImplement.java
@@ -1,5 +1,6 @@
 package com.ecommerce.service.cart;
 
+import com.ecommerce.dto.ResponseDto;
 import com.ecommerce.dto.cart.CartItemDto;
 import com.ecommerce.dto.cart.UpdateCartItemDto;
 import com.ecommerce.entity.Cart;
@@ -95,6 +96,28 @@ public class CartItemServiceImplement implements CartItemService {
     cartItem.setQuantity(updateRequest.getQuantity());
 
     return CartItemDto.Response.fromEntity(cartItem);
+
+  }
+
+  /**
+   * 장바구니 상품 제거
+   *
+   * @param memberId
+   * @param cartItemId
+   * @param token
+   * @return ResponseDto
+   */
+  @Override
+  @Transactional
+  public ResponseDto deleteCartItem(String memberId, Long cartItemId, String token) {
+
+    authService.equalToMemberIdFromToken(memberId, token);
+
+    CartItem cartItem = getCartItemById(cartItemId);
+
+    cartItemRepository.delete(cartItem);
+
+    return ResponseDto.getResponseBody(ResponseCode.CART_ITEM_DELETE_SUCCESS);
 
   }
 

--- a/src/main/java/com/ecommerce/service/cart/CartItemServiceImplement.java
+++ b/src/main/java/com/ecommerce/service/cart/CartItemServiceImplement.java
@@ -31,6 +31,7 @@ public class CartItemServiceImplement implements CartItemService {
 
   /**
    * 장바구니에 상품 담기
+   *
    * @param memberId
    * @param token
    * @param request
@@ -70,6 +71,7 @@ public class CartItemServiceImplement implements CartItemService {
 
   /**
    * memberId 에 해당하는 Cart 조회
+   *
    * @param memberId
    * @return Cart
    */

--- a/src/main/java/com/ecommerce/service/cart/CartItemServiceImplement.java
+++ b/src/main/java/com/ecommerce/service/cart/CartItemServiceImplement.java
@@ -46,7 +46,7 @@ public class CartItemServiceImplement implements CartItemService {
     Product product = productService.getProductById(request.getProductId());
 
     if (product.getStatus() != ProductStatus.IN_STOCK) {
-      throw new CartException(ResponseCode.CANNOT_ADDED_PRODUCT);
+      throw new CartException(ResponseCode.CART_ITEM_CANNOT_ADDED_PRODUCT);
     }
 
     checkExceedStockQuantity(request.getQuantity(), product.getStockQuantity());

--- a/src/main/java/com/ecommerce/service/cart/CartItemServiceImplement.java
+++ b/src/main/java/com/ecommerce/service/cart/CartItemServiceImplement.java
@@ -1,0 +1,86 @@
+package com.ecommerce.service.cart;
+
+import com.ecommerce.dto.ResponseDto;
+import com.ecommerce.dto.cart.CartItemDto;
+import com.ecommerce.entity.Cart;
+import com.ecommerce.entity.CartItem;
+import com.ecommerce.entity.Member;
+import com.ecommerce.entity.Product;
+import com.ecommerce.exception.CartException;
+import com.ecommerce.repository.CartItemRepository;
+import com.ecommerce.repository.CartRepository;
+import com.ecommerce.service.auth.AuthService;
+import com.ecommerce.service.member.MemberService;
+import com.ecommerce.service.product.ProductService;
+import com.ecommerce.type.ProductStatus;
+import com.ecommerce.type.ResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CartItemServiceImplement implements CartItemService {
+
+  private final CartItemRepository cartItemRepository;
+  private final CartRepository cartRepository;
+
+  private final AuthService authService;
+  private final MemberService memberService;
+  private final ProductService productService;
+
+  /**
+   * 장바구니에 상품 담기
+   * @param memberId
+   * @param token
+   * @param request
+   * @return ResponseDto
+   */
+  @Override
+  @Transactional
+  public ResponseDto addCartItem(String memberId, String token, CartItemDto.Request request) {
+
+    authService.equalToMemberIdFromToken(memberId, token);
+
+    Cart cart = getCartByMemberId(memberId);
+
+    Product product = productService.getProductById(request.getProductId());
+
+    if (product.getStatus() != ProductStatus.IN_STOCK) {
+      throw new CartException(ResponseCode.CANNOT_ADDED_PRODUCT);
+    }
+
+    boolean isExists = cartItemRepository.existsByCartAndProduct(cart, product);
+    if (isExists) {
+      throw new CartException(ResponseCode.CART_ITEM_ALREADY_EXISTS);
+    }
+
+    cartItemRepository.save(
+        CartItem.builder()
+            .cart(cart)
+            .product(product)
+            .quantity(request.getQuantity())
+            .price(product.getPrice())
+            .build()
+    );
+
+    return ResponseDto.getResponseBody(ResponseCode.ADDED_CART_ITEM);
+
+  }
+
+  /**
+   * memberId 에 해당하는 Cart 조회
+   * @param memberId
+   * @return Cart
+   */
+  @Transactional(readOnly = true)
+  public Cart getCartByMemberId(String memberId) {
+
+    Member member = memberService.getMemberByMemberId(memberId);
+
+    return cartRepository.findByMember(member)
+        .orElseThrow(() -> new CartException(ResponseCode.CART_NOT_FOUND));
+
+  }
+
+}

--- a/src/main/java/com/ecommerce/service/cart/CartItemServiceImplement.java
+++ b/src/main/java/com/ecommerce/service/cart/CartItemServiceImplement.java
@@ -122,6 +122,27 @@ public class CartItemServiceImplement implements CartItemService {
   }
 
   /**
+   * 장바구니 상품 전체 제거
+   *
+   * @param memberId
+   * @param token
+   * @return ResponseDto
+   */
+  @Override
+  @Transactional
+  public ResponseDto deleteAllCartItem(String memberId, String token) {
+
+    authService.equalToMemberIdFromToken(memberId, token);
+
+    Cart cart = getCartByMemberId(memberId);
+
+    cartItemRepository.deleteAllByCart(cart);
+
+    return ResponseDto.getResponseBody(ResponseCode.CART_ITEM_DELETE_SUCCESS);
+
+  }
+
+  /**
    * CartItem ID 로 조회
    *
    * @param cartItemId

--- a/src/main/java/com/ecommerce/service/cart/CartItemServiceImplement.java
+++ b/src/main/java/com/ecommerce/service/cart/CartItemServiceImplement.java
@@ -1,6 +1,7 @@
 package com.ecommerce.service.cart;
 
 import com.ecommerce.dto.cart.CartItemDto;
+import com.ecommerce.dto.cart.UpdateCartItemDto;
 import com.ecommerce.entity.Cart;
 import com.ecommerce.entity.CartItem;
 import com.ecommerce.entity.Member;
@@ -66,6 +67,48 @@ public class CartItemServiceImplement implements CartItemService {
                 .build()
         )
     );
+
+  }
+
+  /**
+   * 장바구니 상품 수량 수정
+   *
+   * @param memberId
+   * @param token
+   * @param updateRequest
+   * @return CartItemDto.Response
+   */
+  @Override
+  @Transactional
+  public CartItemDto.Response updateCartItem(
+      String memberId, Long cartItemId, String token, UpdateCartItemDto updateRequest
+  ) {
+
+    authService.equalToMemberIdFromToken(memberId, token);
+
+    CartItem cartItem = getCartItemById(cartItemId);
+
+    if (updateRequest.getQuantity() > cartItem.getProduct().getStockQuantity()) {
+      throw new CartException(ResponseCode.CART_ITEM_CANNOT_UPDATE_QUANTITY);
+    }
+
+    cartItem.setQuantity(updateRequest.getQuantity());
+
+    return CartItemDto.Response.fromEntity(cartItem);
+
+  }
+
+  /**
+   * CartItem ID 로 조회
+   *
+   * @param cartItemId
+   * @return CartItem
+   */
+  @Transactional(readOnly = true)
+  public CartItem getCartItemById(Long cartItemId) {
+
+    return cartItemRepository.findById(cartItemId)
+        .orElseThrow(() -> new CartException(ResponseCode.CART_ITEM_NOT_FOUND));
 
   }
 

--- a/src/main/java/com/ecommerce/service/cart/CartService.java
+++ b/src/main/java/com/ecommerce/service/cart/CartService.java
@@ -1,9 +1,12 @@
 package com.ecommerce.service.cart;
 
 import com.ecommerce.dto.cart.CartDto;
+import com.ecommerce.entity.Cart;
 
 public interface CartService {
 
   CartDto getCartDetails(String memberId, String token);
+
+  Cart getCartByMemberId(String memberId);
 
 }

--- a/src/main/java/com/ecommerce/service/cart/CartService.java
+++ b/src/main/java/com/ecommerce/service/cart/CartService.java
@@ -1,0 +1,9 @@
+package com.ecommerce.service.cart;
+
+import com.ecommerce.dto.cart.CartDto;
+
+public interface CartService {
+
+  CartDto getCartDetails(String memberId, String token);
+
+}

--- a/src/main/java/com/ecommerce/service/cart/CartServiceImplement.java
+++ b/src/main/java/com/ecommerce/service/cart/CartServiceImplement.java
@@ -1,0 +1,44 @@
+package com.ecommerce.service.cart;
+
+import com.ecommerce.dto.cart.CartDto;
+import com.ecommerce.entity.Member;
+import com.ecommerce.exception.CartException;
+import com.ecommerce.repository.CartRepository;
+import com.ecommerce.service.auth.AuthService;
+import com.ecommerce.service.member.MemberService;
+import com.ecommerce.type.ResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CartServiceImplement implements CartService {
+
+  private final CartRepository cartRepository;
+
+  private final AuthService authService;
+  private final MemberService memberService;
+
+  /**
+   * 장바구니 조회
+   * @param memberId
+   * @param token
+   * @return CartDto
+   */
+  @Override
+  @Transactional(readOnly = true)
+  public CartDto getCartDetails(String memberId, String token) {
+
+    authService.equalToMemberIdFromToken(memberId, token);
+
+    Member member = memberService.getMemberByMemberId(memberId);
+
+    return CartDto.fromEntity(
+        cartRepository.findByMember(member)
+            .orElseThrow(() -> new CartException(ResponseCode.CART_NOT_FOUND))
+    );
+
+  }
+
+}

--- a/src/main/java/com/ecommerce/service/cart/CartServiceImplement.java
+++ b/src/main/java/com/ecommerce/service/cart/CartServiceImplement.java
@@ -22,6 +22,7 @@ public class CartServiceImplement implements CartService {
 
   /**
    * 장바구니 조회
+   *
    * @param memberId
    * @param token
    * @return CartDto

--- a/src/main/java/com/ecommerce/service/cart/CartServiceImplement.java
+++ b/src/main/java/com/ecommerce/service/cart/CartServiceImplement.java
@@ -1,6 +1,7 @@
 package com.ecommerce.service.cart;
 
 import com.ecommerce.dto.cart.CartDto;
+import com.ecommerce.entity.Cart;
 import com.ecommerce.entity.Member;
 import com.ecommerce.exception.CartException;
 import com.ecommerce.repository.CartRepository;
@@ -39,6 +40,22 @@ public class CartServiceImplement implements CartService {
         cartRepository.findByMember(member)
             .orElseThrow(() -> new CartException(ResponseCode.CART_NOT_FOUND))
     );
+
+  }
+
+  /**
+   * memberId 에 해당하는 Cart 조회
+   *
+   * @param memberId
+   * @return Cart
+   */
+  @Transactional(readOnly = true)
+  public Cart getCartByMemberId(String memberId) {
+
+    Member member = memberService.getMemberByMemberId(memberId);
+
+    return cartRepository.findByMember(member)
+        .orElseThrow(() -> new CartException(ResponseCode.CART_NOT_FOUND));
 
   }
 

--- a/src/main/java/com/ecommerce/type/ResponseCode.java
+++ b/src/main/java/com/ecommerce/type/ResponseCode.java
@@ -35,6 +35,8 @@ public enum ResponseCode {
   PRODUCT_NOT_FOUND("상품이 존재하지 않습니다."),
   PRODUCT_DELETE_SUCCESS("상품을 정상적으로 삭제했습니다."),
 
+  CART_NOT_FOUND("장바구니가 존재하지 않습니다."),
+
   REVIEW_NOT_FOUND("리뷰가 존재하지 않습니다."),
   REVIEW_ALREADY_EXISTS("리뷰가 이미 존재 합니다."),
   REVIEW_NO_AUTHORIZATION("리뷰 작성할 권한이 없습니다."),

--- a/src/main/java/com/ecommerce/type/ResponseCode.java
+++ b/src/main/java/com/ecommerce/type/ResponseCode.java
@@ -36,6 +36,9 @@ public enum ResponseCode {
   PRODUCT_DELETE_SUCCESS("상품을 정상적으로 삭제했습니다."),
 
   CART_NOT_FOUND("장바구니가 존재하지 않습니다."),
+  CANNOT_ADDED_PRODUCT("장바구니에 추가할수 없는 상품입니다."),
+  ADDED_CART_ITEM("상품이 장바구니에 추가 되었습니다."),
+  CART_ITEM_ALREADY_EXISTS("장바구니에 이미 존재하는 상품입니다."),
 
   REVIEW_NOT_FOUND("리뷰가 존재하지 않습니다."),
   REVIEW_ALREADY_EXISTS("리뷰가 이미 존재 합니다."),

--- a/src/main/java/com/ecommerce/type/ResponseCode.java
+++ b/src/main/java/com/ecommerce/type/ResponseCode.java
@@ -16,10 +16,10 @@ public enum ResponseCode {
   CERTIFICATION_NUMBER_FAIL("인증되지 않았습니다. 정확한 인증번호를 입력해 주세요."),
   CERTIFICATION_NUMBER_SUCCESS("정상적으로 인증되었습니다."),
 
-  AVAILABLE_USER_ID("사용 가능한 사용자 ID 입니다."),
+  MEMBER_ID_AVAILABLE("사용 가능한 사용자 ID 입니다."),
   MEMBER_NOT_FOUND("사용자가 존재하지 않습니다."),
   MEMBER_DELETE_SUCCESS("사용자 정보를 정상적으로 삭제 했습니다."),
-  PASSWORD_UNMATCHED("비밀번호가 일치하지 않습니다."),
+  MEMBER_PASSWORD_UNMATCHED("비밀번호가 일치하지 않습니다."),
   MEMBER_ALREADY_EXISTS("이미 존재하는 사용자 입니다."),
   MEMBER_UNMATCHED("사용자 정보가 일치하지 않습니다."),
   SIGN_IN_FAIL("로그인을 실패했습니다."),
@@ -27,8 +27,7 @@ public enum ResponseCode {
 
   MAIL_SEND_SUCCESS("메일이 정상적으로 전송되었습니다."),
   MAIL_SEND_FAIL("메일 전송을 실패했습니다."),
-
-  DOSE_NOT_EXISTS_CERTIFICATION("이메일 인증이 진행되지 않았습니다. 이메일 인증을 진행해 주세요."),
+  MAIL_CERTIFICATION_DOSE_NOT_EXISTS("이메일 인증이 진행되지 않았습니다. 이메일 인증을 진행해 주세요."),
 
   REDIS_DATA_NOT_FOUND("해당 Key 값의 데이터가 존재하지 않습니다."),
 
@@ -36,8 +35,8 @@ public enum ResponseCode {
   PRODUCT_DELETE_SUCCESS("상품을 정상적으로 삭제했습니다."),
 
   CART_NOT_FOUND("장바구니가 존재하지 않습니다."),
-  CANNOT_ADDED_PRODUCT("장바구니에 추가할수 없는 상품입니다."),
-  ADDED_CART_ITEM("상품이 장바구니에 추가 되었습니다."),
+  CART_ITEM_CANNOT_ADDED_PRODUCT("장바구니에 추가할수 없는 상품입니다."),
+  CART_ITEM_ADDED("상품이 장바구니에 추가 되었습니다."),
   CART_ITEM_ALREADY_EXISTS("장바구니에 이미 존재하는 상품입니다."),
   CART_ITEM_NOT_FOUND("장바구니에 존재하지 않는 상품입니다."),
   CART_ITEM_EXCEED_QUANTITY("상품의 재고 수량 보다 많은 수량을 추가 할 수 없습니다."),

--- a/src/main/java/com/ecommerce/type/ResponseCode.java
+++ b/src/main/java/com/ecommerce/type/ResponseCode.java
@@ -41,6 +41,7 @@ public enum ResponseCode {
   CART_ITEM_ALREADY_EXISTS("장바구니에 이미 존재하는 상품입니다."),
   CART_ITEM_NOT_FOUND("장바구니에 존재하지 않는 상품입니다."),
   CART_ITEM_CANNOT_UPDATE_QUANTITY("장바구니의 상품 수량을 업데이트할수 없습니다."),
+  CART_ITEM_DELETE_SUCCESS("장바구니의 상품 성공적으로 삭제 되었습니다."),
 
   REVIEW_NOT_FOUND("리뷰가 존재하지 않습니다."),
   REVIEW_ALREADY_EXISTS("리뷰가 이미 존재 합니다."),

--- a/src/main/java/com/ecommerce/type/ResponseCode.java
+++ b/src/main/java/com/ecommerce/type/ResponseCode.java
@@ -40,7 +40,7 @@ public enum ResponseCode {
   ADDED_CART_ITEM("상품이 장바구니에 추가 되었습니다."),
   CART_ITEM_ALREADY_EXISTS("장바구니에 이미 존재하는 상품입니다."),
   CART_ITEM_NOT_FOUND("장바구니에 존재하지 않는 상품입니다."),
-  CART_ITEM_CANNOT_UPDATE_QUANTITY("장바구니의 상품 수량을 업데이트할수 없습니다."),
+  CART_ITEM_EXCEED_QUANTITY("상품의 재고 수량 보다 많은 수량을 추가 할 수 없습니다."),
   CART_ITEM_DELETE_SUCCESS("장바구니의 상품 성공적으로 삭제 되었습니다."),
 
   REVIEW_NOT_FOUND("리뷰가 존재하지 않습니다."),

--- a/src/main/java/com/ecommerce/type/ResponseCode.java
+++ b/src/main/java/com/ecommerce/type/ResponseCode.java
@@ -39,6 +39,8 @@ public enum ResponseCode {
   CANNOT_ADDED_PRODUCT("장바구니에 추가할수 없는 상품입니다."),
   ADDED_CART_ITEM("상품이 장바구니에 추가 되었습니다."),
   CART_ITEM_ALREADY_EXISTS("장바구니에 이미 존재하는 상품입니다."),
+  CART_ITEM_NOT_FOUND("장바구니에 존재하지 않는 상품입니다."),
+  CART_ITEM_CANNOT_UPDATE_QUANTITY("장바구니의 상품 수량을 업데이트할수 없습니다."),
 
   REVIEW_NOT_FOUND("리뷰가 존재하지 않습니다."),
   REVIEW_ALREADY_EXISTS("리뷰가 이미 존재 합니다."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,9 @@ spring:
   jpa:
     show-sql: true
     database: mysql
+    hibernate:
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 
   jwt:
     secret: ${JWT_SECRET}

--- a/src/test/java/com/ecommerce/service/auth/AuthServiceImplementTest.java
+++ b/src/test/java/com/ecommerce/service/auth/AuthServiceImplementTest.java
@@ -80,7 +80,7 @@ public class AuthServiceImplementTest {
     verify(memberRepository, times(1))
         .existsByMemberId(eq("testUser"));
 
-    assertEquals(ResponseCode.AVAILABLE_USER_ID, response.getCode());
+    assertEquals(ResponseCode.MEMBER_ID_AVAILABLE, response.getCode());
   }
 
   @Test
@@ -334,7 +334,7 @@ public class AuthServiceImplementTest {
         .checkVerified(eq("testUser:verified"));
 
     assertThat(certificationException.getErrorCode())
-        .isEqualTo(ResponseCode.DOSE_NOT_EXISTS_CERTIFICATION);
+        .isEqualTo(ResponseCode.MAIL_CERTIFICATION_DOSE_NOT_EXISTS);
   }
 
   @Test
@@ -475,7 +475,7 @@ public class AuthServiceImplementTest {
     verify(passwordEncoder, times(1))
         .matches(eq("testPassword"), eq("encodedPassword"));
 
-    assertThat(memberException.getErrorCode()).isEqualTo(ResponseCode.PASSWORD_UNMATCHED);
+    assertThat(memberException.getErrorCode()).isEqualTo(ResponseCode.MEMBER_PASSWORD_UNMATCHED);
   }
 
   @Test

--- a/src/test/java/com/ecommerce/service/cart/CartItemServiceImplementTest.java
+++ b/src/test/java/com/ecommerce/service/cart/CartItemServiceImplementTest.java
@@ -1,0 +1,878 @@
+package com.ecommerce.service.cart;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.ecommerce.dto.ResponseDto;
+import com.ecommerce.dto.cart.CartItemDto;
+import com.ecommerce.dto.cart.UpdateCartItemDto;
+import com.ecommerce.entity.Cart;
+import com.ecommerce.entity.CartItem;
+import com.ecommerce.entity.Member;
+import com.ecommerce.entity.Product;
+import com.ecommerce.exception.CartException;
+import com.ecommerce.exception.MemberException;
+import com.ecommerce.exception.ProductException;
+import com.ecommerce.repository.CartItemRepository;
+import com.ecommerce.service.auth.AuthService;
+import com.ecommerce.service.product.ProductService;
+import com.ecommerce.type.LoginType;
+import com.ecommerce.type.ProductStatus;
+import com.ecommerce.type.ResponseCode;
+import com.ecommerce.type.Role;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CartItemServiceImplementTest {
+
+  @Mock
+  private CartItemRepository cartItemRepository;
+
+  @Mock
+  private AuthService authService;
+
+  @Mock
+  private ProductService productService;
+
+  @Mock
+  private CartService cartService;
+
+  @InjectMocks
+  private CartItemServiceImplement cartItemServiceImplement;
+
+  @Test
+  @DisplayName("장바구니에 상품 담기 - 성공 (cart, product 에 해당하는 cartItem 존재 X)")
+  void testGetCartDetails_Success_NotFoundCartItem() {
+    // given
+    CartItemDto.Request request = CartItemDto.Request.builder()
+        .productId(1L)
+        .quantity(3)
+        .build();
+
+    Member member = Member.builder()
+        .memberId("testUser")
+        .memberName("test")
+        .email("test@email.com")
+        .password("encodedPassword")
+        .phoneNumber("01011112222")
+        .address("test시 test구 test로 111")
+        .role(Role.CUSTOMER)
+        .loginType(LoginType.APP)
+        .build();
+
+    Product product = Product.builder()
+        .productName("testProductName1")
+        .description("testProductDescription1")
+        .stockQuantity(3)
+        .price(BigDecimal.valueOf(10001.0))
+        .status(ProductStatus.IN_STOCK)
+        .rating(BigDecimal.ZERO)
+        .member(new Member())
+        .build();
+
+    Cart cart = Cart.builder()
+        .member(member)
+        .cartItems(List.of())
+        .build();
+
+    CartItem cartItem = CartItem.builder()
+        .cart(cart)
+        .product(product)
+        .price(product.getPrice().multiply(BigDecimal.valueOf(3)))
+        .quantity(3)
+        .build();
+
+    willDoNothing().given(authService)
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    given(cartService.getCartByMemberId(eq("testUser"))).willReturn(cart);
+    given(productService.getProductById(eq(1L))).willReturn(product);
+    given(cartItemRepository.findByCartAndProduct(eq(cart), eq(product)))
+        .willReturn(Optional.empty());
+    given(cartItemRepository.save(any(CartItem.class)))
+        .willReturn(cartItem);
+
+    ArgumentCaptor<CartItem> cartItemCaptor = ArgumentCaptor.forClass(CartItem.class);
+
+    // when
+    CartItemDto.Response response
+        = cartItemServiceImplement.addCartItem("testUser", "token", request);
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+    verify(cartService, times(1))
+        .getCartByMemberId(eq("testUser"));
+    verify(productService, times(1))
+        .getProductById(eq(1L));
+    verify(cartItemRepository, times(1))
+        .findByCartAndProduct(eq(cart), eq(product));
+    verify(cartItemRepository, times(1))
+        .save(cartItemCaptor.capture());
+
+    assertThat(cartItemCaptor.getValue()).isNotNull();
+    assertThat(cartItemCaptor.getValue().getCart()).isEqualTo(cart);
+    assertThat(cartItemCaptor.getValue().getProduct()).isEqualTo(product);
+    assertThat(cartItemCaptor.getValue().getQuantity()).isEqualTo(3);
+    assertThat(cartItemCaptor.getValue().getPrice()).isEqualTo(product.getPrice());
+  }
+
+  @Test
+  @DisplayName("장바구니에 상품 담기 - 성공 (cart, product 에 해당하는 cartItem 존재 O)")
+  void testGetCartDetails_Success_FoundCartItem() {
+    // given
+    CartItemDto.Request request = CartItemDto.Request.builder()
+        .productId(1L)
+        .quantity(3)
+        .build();
+
+    Member member = Member.builder()
+        .memberId("testUser")
+        .memberName("test")
+        .email("test@email.com")
+        .password("encodedPassword")
+        .phoneNumber("01011112222")
+        .address("test시 test구 test로 111")
+        .role(Role.CUSTOMER)
+        .loginType(LoginType.APP)
+        .build();
+
+    Product product = Product.builder()
+        .productName("testProductName1")
+        .description("testProductDescription1")
+        .stockQuantity(10)
+        .price(BigDecimal.valueOf(10001.0))
+        .status(ProductStatus.IN_STOCK)
+        .rating(BigDecimal.ZERO)
+        .member(new Member())
+        .build();
+
+    Cart cart = Cart.builder()
+        .member(member)
+        .cartItems(List.of())
+        .build();
+
+    CartItem cartItem = CartItem.builder()
+        .cart(cart)
+        .product(product)
+        .price(product.getPrice().multiply(BigDecimal.valueOf(3)))
+        .quantity(3)
+        .build();
+
+    willDoNothing().given(authService)
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    given(cartService.getCartByMemberId(eq("testUser"))).willReturn(cart);
+    given(productService.getProductById(eq(1L))).willReturn(product);
+    given(cartItemRepository.findByCartAndProduct(eq(cart), eq(product)))
+        .willReturn(Optional.of(cartItem));
+
+    // when
+    CartItemDto.Response response
+        = cartItemServiceImplement.addCartItem("testUser", "token", request);
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+    verify(cartService, times(1))
+        .getCartByMemberId(eq("testUser"));
+    verify(productService, times(1))
+        .getProductById(eq(1L));
+    verify(cartItemRepository, times(1))
+        .findByCartAndProduct(eq(cart), eq(product));
+
+    assertThat(response.getQuantity()).isEqualTo(6);
+  }
+
+  @Test
+  @DisplayName("장바구니에 상품 담기 - 실패 (토큰에 있는 멤버 정보와 불일치)")
+  void testGetCartDetails_Fail_MemberUnMatched() {
+    // given
+    CartItemDto.Request request = CartItemDto.Request.builder()
+        .productId(1L)
+        .quantity(3)
+        .build();
+
+    doThrow(new MemberException(ResponseCode.MEMBER_UNMATCHED))
+        .when(authService).equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    // when
+    MemberException memberException = assertThrows(MemberException.class,
+        () -> cartItemServiceImplement.addCartItem("testUser", "token", request));
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    assertThat(memberException.getErrorCode()).isEqualTo(ResponseCode.MEMBER_UNMATCHED);
+  }
+
+  @Test
+  @DisplayName("장바구니에 상품 담기 - 실패 (존재하지 않는 멤버)")
+  void testGetCartDetails_Fail_MemberNotFound() {
+    // given
+    CartItemDto.Request request = CartItemDto.Request.builder()
+        .productId(1L)
+        .quantity(3)
+        .build();
+
+    willDoNothing().given(authService)
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    doThrow(new MemberException(ResponseCode.MEMBER_NOT_FOUND))
+        .when(cartService).getCartByMemberId(eq("testUser"));
+
+    // when
+    MemberException memberException = assertThrows(MemberException.class,
+        () -> cartItemServiceImplement.addCartItem("testUser", "token", request));
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+    verify(cartService, times(1))
+        .getCartByMemberId(eq("testUser"));
+
+    assertThat(memberException.getErrorCode()).isEqualTo(ResponseCode.MEMBER_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("장바구니에 상품 담기 - 실패 (존재하지 않는 장바구니)")
+  void testGetCartDetails_Fail_CartNotFound() {
+    // given
+    CartItemDto.Request request = CartItemDto.Request.builder()
+        .productId(1L)
+        .quantity(3)
+        .build();
+
+    willDoNothing().given(authService)
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    doThrow(new CartException(ResponseCode.CART_NOT_FOUND))
+        .when(cartService).getCartByMemberId(eq("testUser"));
+
+    // when
+    CartException cartException = assertThrows(CartException.class,
+        () -> cartItemServiceImplement.addCartItem("testUser", "token", request));
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+    verify(cartService, times(1))
+        .getCartByMemberId(eq("testUser"));
+
+    assertThat(cartException.getErrorCode()).isEqualTo(ResponseCode.CART_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("장바구니에 상품 담기 - 실패 (존재하지 않는 상품)")
+  void testGetCartDetails_Fail_ProductNotFound() {
+    // given
+    CartItemDto.Request request = CartItemDto.Request.builder()
+        .productId(1L)
+        .quantity(3)
+        .build();
+
+    Member member = Member.builder()
+        .memberId("testUser")
+        .memberName("test")
+        .email("test@email.com")
+        .password("encodedPassword")
+        .phoneNumber("01011112222")
+        .address("test시 test구 test로 111")
+        .role(Role.CUSTOMER)
+        .loginType(LoginType.APP)
+        .build();
+
+    Cart cart = Cart.builder()
+        .member(member)
+        .cartItems(List.of())
+        .build();
+
+    willDoNothing().given(authService)
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    given(cartService.getCartByMemberId(eq("testUser"))).willReturn(cart);
+
+    doThrow(new ProductException(ResponseCode.PRODUCT_NOT_FOUND))
+        .when(productService).getProductById(eq(1L));
+
+    // when
+    ProductException productException = assertThrows(ProductException.class,
+        () -> cartItemServiceImplement.addCartItem("testUser", "token", request));
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+    verify(cartService, times(1))
+        .getCartByMemberId(eq("testUser"));
+    verify(productService, times(1))
+        .getProductById(eq(1L));
+
+    assertThat(productException.getErrorCode()).isEqualTo(ResponseCode.PRODUCT_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("장바구니에 상품 담기 - 실패 (IN_STOCK 이 아닌 상품)")
+  void testGetCartDetails_Fail_ProductDoesNotIN_STOCK() {
+    // given
+    CartItemDto.Request request = CartItemDto.Request.builder()
+        .productId(1L)
+        .quantity(3)
+        .build();
+
+    Member member = Member.builder()
+        .memberId("testUser")
+        .memberName("test")
+        .email("test@email.com")
+        .password("encodedPassword")
+        .phoneNumber("01011112222")
+        .address("test시 test구 test로 111")
+        .role(Role.CUSTOMER)
+        .loginType(LoginType.APP)
+        .build();
+
+    Product product1 = Product.builder()
+        .productName("testProductName1")
+        .description("testProductDescription1")
+        .stockQuantity(3)
+        .price(BigDecimal.valueOf(10001.0))
+        .status(ProductStatus.NO_STOCK)
+        .rating(BigDecimal.ZERO)
+        .member(new Member())
+        .build();
+
+    Cart cart = Cart.builder()
+        .member(member)
+        .cartItems(List.of())
+        .build();
+
+    willDoNothing().given(authService)
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    given(cartService.getCartByMemberId(eq("testUser"))).willReturn(cart);
+    given(productService.getProductById(eq(1L))).willReturn(product1);
+
+    // when
+    CartException cartException = assertThrows(CartException.class,
+        () -> cartItemServiceImplement.addCartItem("testUser", "token", request));
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+    verify(cartService, times(1))
+        .getCartByMemberId(eq("testUser"));
+    verify(productService, times(1))
+        .getProductById(eq(1L));
+
+    assertThat(cartException.getErrorCode()).isEqualTo(ResponseCode.CANNOT_ADDED_PRODUCT);
+  }
+
+  @Test
+  @DisplayName("장바구니에 상품 담기 - 실패 (상품 재고 부족 - request 수량)")
+  void testGetCartDetails_Fail_ExceedProductStockQuantity_RequestQuantity() {
+    // given
+    CartItemDto.Request request = CartItemDto.Request.builder()
+        .productId(1L)
+        .quantity(3)
+        .build();
+
+    Member member = Member.builder()
+        .memberId("testUser")
+        .memberName("test")
+        .email("test@email.com")
+        .password("encodedPassword")
+        .phoneNumber("01011112222")
+        .address("test시 test구 test로 111")
+        .role(Role.CUSTOMER)
+        .loginType(LoginType.APP)
+        .build();
+
+    Product product = Product.builder()
+        .productName("testProductName1")
+        .description("testProductDescription1")
+        .stockQuantity(2)
+        .price(BigDecimal.valueOf(10001.0))
+        .status(ProductStatus.IN_STOCK)
+        .rating(BigDecimal.ZERO)
+        .member(new Member())
+        .build();
+
+    Cart cart = Cart.builder()
+        .member(member)
+        .cartItems(List.of())
+        .build();
+
+    willDoNothing().given(authService)
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    given(cartService.getCartByMemberId(eq("testUser"))).willReturn(cart);
+    given(productService.getProductById(eq(1L))).willReturn(product);
+
+    // when
+    CartException cartException = assertThrows(CartException.class,
+        () -> cartItemServiceImplement.addCartItem("testUser", "token", request));
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+    verify(cartService, times(1))
+        .getCartByMemberId(eq("testUser"));
+    verify(productService, times(1))
+        .getProductById(eq(1L));
+
+    assertThat(cartException.getErrorCode()).isEqualTo(ResponseCode.CART_ITEM_EXCEED_QUANTITY);
+  }
+
+  @Test
+  @DisplayName("장바구니에 상품 담기 - 실패 (상품 재고 부족 - request 수량 + 기존 cartItem 수량)")
+  void testGetCartDetails_Fail_ExceedProductStockQuantity_TotalQuantity() {
+    // given
+    CartItemDto.Request request = CartItemDto.Request.builder()
+        .productId(1L)
+        .quantity(3)
+        .build();
+
+    Member member = Member.builder()
+        .memberId("testUser")
+        .memberName("test")
+        .email("test@email.com")
+        .password("encodedPassword")
+        .phoneNumber("01011112222")
+        .address("test시 test구 test로 111")
+        .role(Role.CUSTOMER)
+        .loginType(LoginType.APP)
+        .build();
+
+    Product product = Product.builder()
+        .productName("testProductName1")
+        .description("testProductDescription1")
+        .stockQuantity(3)
+        .price(BigDecimal.valueOf(10001.0))
+        .status(ProductStatus.IN_STOCK)
+        .rating(BigDecimal.ZERO)
+        .member(new Member())
+        .build();
+
+    Cart cart = Cart.builder()
+        .member(member)
+        .cartItems(List.of())
+        .build();
+
+    CartItem cartItem = CartItem.builder()
+        .cart(cart)
+        .product(product)
+        .price(product.getPrice().multiply(BigDecimal.valueOf(3)))
+        .quantity(3)
+        .build();
+
+    willDoNothing().given(authService)
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    given(cartService.getCartByMemberId(eq("testUser"))).willReturn(cart);
+    given(productService.getProductById(eq(1L))).willReturn(product);
+    given(cartItemRepository.findByCartAndProduct(eq(cart), eq(product)))
+        .willReturn(Optional.of(cartItem));
+
+    // when
+    CartException cartException = assertThrows(CartException.class,
+        () -> cartItemServiceImplement.addCartItem("testUser", "token", request));
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+    verify(cartService, times(1))
+        .getCartByMemberId(eq("testUser"));
+    verify(productService, times(1))
+        .getProductById(eq(1L));
+    verify(cartItemRepository, times(1))
+        .findByCartAndProduct(eq(cart), eq(product));
+
+    assertThat(cartException.getErrorCode()).isEqualTo(ResponseCode.CART_ITEM_EXCEED_QUANTITY);
+  }
+
+  @Test
+  @DisplayName("장바구니 상품 수정 - 성공")
+  void testUpdateCartItem_Success() {
+    // given
+    UpdateCartItemDto updateRequest = UpdateCartItemDto.builder()
+        .quantity(2)
+        .build();
+
+    Member member = Member.builder()
+        .memberId("testUser")
+        .memberName("test")
+        .email("test@email.com")
+        .password("encodedPassword")
+        .phoneNumber("01011112222")
+        .address("test시 test구 test로 111")
+        .role(Role.CUSTOMER)
+        .loginType(LoginType.APP)
+        .build();
+
+    Product product = Product.builder()
+        .productName("testProductName1")
+        .description("testProductDescription1")
+        .stockQuantity(3)
+        .price(BigDecimal.valueOf(10001.0))
+        .status(ProductStatus.IN_STOCK)
+        .rating(BigDecimal.ZERO)
+        .member(new Member())
+        .build();
+
+    Cart cart = Cart.builder()
+        .member(member)
+        .cartItems(List.of())
+        .build();
+
+    CartItem cartItem = CartItem.builder()
+        .cart(cart)
+        .product(product)
+        .price(product.getPrice().multiply(BigDecimal.valueOf(3)))
+        .quantity(1)
+        .build();
+
+    willDoNothing().given(authService)
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    given(cartItemRepository.findById(eq(1L))).willReturn(Optional.of(cartItem));
+
+    // when
+    CartItemDto.Response response = cartItemServiceImplement
+        .updateCartItem("testUser", 1L, "token", updateRequest);
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+    verify(cartItemRepository, times(1))
+        .findById(eq(1L));
+
+    assertThat(response.getQuantity()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("장바구니 상품 수정 - 실패 (토큰에 있는 멤버 정보와 불일치)")
+  void testUpdateCartItem_Fail_MemberUnMatched() {
+    // given
+    UpdateCartItemDto updateRequest = UpdateCartItemDto.builder()
+        .quantity(2)
+        .build();
+
+    doThrow(new MemberException(ResponseCode.MEMBER_UNMATCHED))
+        .when(authService).equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    // when
+    MemberException memberException = assertThrows(MemberException.class, () -> cartItemServiceImplement
+            .updateCartItem("testUser", 1L, "token", updateRequest));
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    assertThat(memberException.getErrorCode()).isEqualTo(ResponseCode.MEMBER_UNMATCHED);
+  }
+
+  @Test
+  @DisplayName("장바구니 상품 수정 - 실패 (존재하지 않는 장바구니 상품)")
+  void testUpdateCartItem_Fail_CartItemNotFound() {
+    // given
+    UpdateCartItemDto updateRequest = UpdateCartItemDto.builder()
+        .quantity(2)
+        .build();
+
+    willDoNothing().given(authService)
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    doThrow(new CartException(ResponseCode.CART_ITEM_NOT_FOUND))
+        .when(cartItemRepository).findById(eq(1L));
+
+    // when
+    CartException cartException = assertThrows(CartException.class, () -> cartItemServiceImplement
+            .updateCartItem("testUser", 1L, "token", updateRequest));
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+    verify(cartItemRepository, times(1))
+        .findById(eq(1L));
+
+    assertThat(cartException.getErrorCode()).isEqualTo(ResponseCode.CART_ITEM_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("장바구니 상품 수정 - 실패 (상품 재고 부족)")
+  void testUpdateCartItem_Fail_ShortageProductStockQuantity() {
+    // given
+    UpdateCartItemDto updateRequest = UpdateCartItemDto.builder()
+        .quantity(2)
+        .build();
+
+    Member member = Member.builder()
+        .memberId("testUser")
+        .memberName("test")
+        .email("test@email.com")
+        .password("encodedPassword")
+        .phoneNumber("01011112222")
+        .address("test시 test구 test로 111")
+        .role(Role.CUSTOMER)
+        .loginType(LoginType.APP)
+        .build();
+
+    Product product = Product.builder()
+        .productName("testProductName1")
+        .description("testProductDescription1")
+        .stockQuantity(1)
+        .price(BigDecimal.valueOf(10001.0))
+        .status(ProductStatus.IN_STOCK)
+        .rating(BigDecimal.ZERO)
+        .member(new Member())
+        .build();
+
+    Cart cart = Cart.builder()
+        .member(member)
+        .cartItems(List.of())
+        .build();
+
+    CartItem cartItem = CartItem.builder()
+        .cart(cart)
+        .product(product)
+        .price(product.getPrice().multiply(BigDecimal.valueOf(3)))
+        .quantity(3)
+        .build();
+
+    willDoNothing().given(authService)
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    given(cartItemRepository.findById(eq(1L))).willReturn(Optional.of(cartItem));
+
+    // when
+    CartException cartException = assertThrows(CartException.class, () -> cartItemServiceImplement
+            .updateCartItem("testUser", 1L, "token", updateRequest));
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+    verify(cartItemRepository, times(1))
+        .findById(eq(1L));
+
+    assertThat(cartException.getErrorCode()).isEqualTo(ResponseCode.CART_ITEM_EXCEED_QUANTITY);
+  }
+
+  @Test
+  @DisplayName("장바구니 상품 삭제 - 성공")
+  void testDeleteCartItem_Success() {
+    // given
+    Member member = Member.builder()
+        .memberId("testUser")
+        .memberName("test")
+        .email("test@email.com")
+        .password("encodedPassword")
+        .phoneNumber("01011112222")
+        .address("test시 test구 test로 111")
+        .role(Role.CUSTOMER)
+        .loginType(LoginType.APP)
+        .build();
+
+    Product product1 = Product.builder()
+        .productName("testProductName1")
+        .description("testProductDescription1")
+        .stockQuantity(1)
+        .price(BigDecimal.valueOf(10001.0))
+        .status(ProductStatus.IN_STOCK)
+        .rating(BigDecimal.ZERO)
+        .member(new Member())
+        .build();
+
+    Cart cart = Cart.builder()
+        .member(member)
+        .cartItems(List.of())
+        .build();
+
+    CartItem cartItem = CartItem.builder()
+        .cart(cart)
+        .product(product1)
+        .price(product1.getPrice().multiply(BigDecimal.valueOf(3)))
+        .quantity(3)
+        .build();
+
+    willDoNothing().given(authService)
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    given(cartItemRepository.findById(eq(1L))).willReturn(Optional.of(cartItem));
+
+    // when
+    ResponseDto responseDto =
+        cartItemServiceImplement.deleteCartItem("testUser", 1L, "token");
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+    verify(cartItemRepository, times(1))
+        .findById(eq(1L));
+    verify(cartItemRepository, times(1))
+        .delete(eq(cartItem));
+
+    assertThat(responseDto.getCode()).isEqualTo(ResponseCode.CART_ITEM_DELETE_SUCCESS);
+  }
+
+  @Test
+  @DisplayName("장바구니 상품 삭제 - 실패 (토큰에 있는 멤버 정보와 불일치)")
+  void testDeleteCartItem_Fail_MemberUnMatched() {
+    // given
+    doThrow(new MemberException(ResponseCode.MEMBER_UNMATCHED))
+        .when(authService).equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    // when
+    MemberException memberException = assertThrows(MemberException.class,
+        () -> cartItemServiceImplement.deleteCartItem("testUser", 1L, "token"));
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    assertThat(memberException.getErrorCode()).isEqualTo(ResponseCode.MEMBER_UNMATCHED);
+  }
+
+  @Test
+  @DisplayName("장바구니 상품 삭제 - 실패 (존재하지 않는 장바구니 상품)")
+  void testDeleteCartItem_Fail_CartItemNotFound() {
+    // given
+    willDoNothing().given(authService)
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    doThrow(new CartException(ResponseCode.CART_NOT_FOUND))
+        .when(cartItemRepository).findById(eq(1L));
+
+    // when
+    CartException cartException = assertThrows(CartException.class, () ->
+        cartItemServiceImplement.deleteCartItem("testUser", 1L, "token"));
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+    verify(cartItemRepository, times(1))
+        .findById(eq(1L));
+
+    assertThat(cartException.getErrorCode()).isEqualTo(ResponseCode.CART_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("장바구니 상품 전체 삭제 - 성공")
+  void testDeleteAllCartItem_Success() {
+    // given
+    Member member = Member.builder()
+        .memberId("testUser")
+        .memberName("test")
+        .email("test@email.com")
+        .password("encodedPassword")
+        .phoneNumber("01011112222")
+        .address("test시 test구 test로 111")
+        .role(Role.CUSTOMER)
+        .loginType(LoginType.APP)
+        .build();
+
+    Cart cart = Cart.builder()
+        .member(member)
+        .cartItems(List.of())
+        .build();
+
+    willDoNothing().given(authService)
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    given(cartService.getCartByMemberId(eq("testUser"))).willReturn(cart);
+
+    // when
+    ResponseDto responseDto =
+        cartItemServiceImplement.deleteAllCartItem("testUser", "token");
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+    verify(cartService, times(1))
+        .getCartByMemberId(eq("testUser"));
+    verify(cartItemRepository, times(1))
+        .deleteAllByCart(eq(cart));
+
+    assertThat(responseDto.getCode()).isEqualTo(ResponseCode.CART_ITEM_DELETE_SUCCESS);
+  }
+
+  @Test
+  @DisplayName("장바구니 상품 전체 삭제 - 실패 (토큰에 있는 멤버 정보와 불일치)")
+  void testDeleteAllCartItem_Fail_MemberUnMatched() {
+    // given
+    doThrow(new MemberException(ResponseCode.MEMBER_UNMATCHED))
+        .when(authService).equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    // when
+    MemberException memberException = assertThrows(MemberException.class,
+        () -> cartItemServiceImplement.deleteAllCartItem("testUser", "token"));
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    assertThat(memberException.getErrorCode()).isEqualTo(ResponseCode.MEMBER_UNMATCHED);
+  }
+
+  @Test
+  @DisplayName("장바구니 상품 전체 삭제 - 실패 (존재하지 않는 멤버)")
+  void testDeleteAllCartItem_Fail_MemberNotFound() {
+    // given
+    willDoNothing().given(authService)
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    doThrow(new MemberException(ResponseCode.MEMBER_NOT_FOUND))
+        .when(cartService).getCartByMemberId(eq("testUser"));
+
+    // when
+    MemberException memberException = assertThrows(MemberException.class,
+        () -> cartItemServiceImplement.deleteAllCartItem("testUser", "token"));
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+    verify(cartService, times(1))
+        .getCartByMemberId(eq("testUser"));
+
+    assertThat(memberException.getErrorCode()).isEqualTo(ResponseCode.MEMBER_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("장바구니 상품 전체 삭제 - 실패 (존재하지 않는 장바구니)")
+  void testDeleteAllCartItem_Fail_CartNotFound() {
+    // given
+    willDoNothing().given(authService)
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    doThrow(new CartException(ResponseCode.CART_NOT_FOUND))
+        .when(cartService).getCartByMemberId(eq("testUser"));
+
+    // when
+    CartException cartException = assertThrows(CartException.class,
+        () -> cartItemServiceImplement.deleteAllCartItem("testUser", "token"));
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+    verify(cartService, times(1))
+        .getCartByMemberId(eq("testUser"));
+
+    assertThat(cartException.getErrorCode()).isEqualTo(ResponseCode.CART_NOT_FOUND);
+  }
+
+}

--- a/src/test/java/com/ecommerce/service/cart/CartItemServiceImplementTest.java
+++ b/src/test/java/com/ecommerce/service/cart/CartItemServiceImplementTest.java
@@ -380,7 +380,7 @@ class CartItemServiceImplementTest {
     verify(productService, times(1))
         .getProductById(eq(1L));
 
-    assertThat(cartException.getErrorCode()).isEqualTo(ResponseCode.CANNOT_ADDED_PRODUCT);
+    assertThat(cartException.getErrorCode()).isEqualTo(ResponseCode.CART_ITEM_CANNOT_ADDED_PRODUCT);
   }
 
   @Test

--- a/src/test/java/com/ecommerce/service/cart/CartServiceImplementTest.java
+++ b/src/test/java/com/ecommerce/service/cart/CartServiceImplementTest.java
@@ -1,0 +1,283 @@
+package com.ecommerce.service.cart;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.ecommerce.dto.cart.CartDto;
+import com.ecommerce.entity.Cart;
+import com.ecommerce.entity.CartItem;
+import com.ecommerce.entity.Member;
+import com.ecommerce.entity.Product;
+import com.ecommerce.exception.CartException;
+import com.ecommerce.exception.MemberException;
+import com.ecommerce.repository.CartRepository;
+import com.ecommerce.service.auth.AuthService;
+import com.ecommerce.service.member.MemberService;
+import com.ecommerce.type.LoginType;
+import com.ecommerce.type.ProductStatus;
+import com.ecommerce.type.ResponseCode;
+import com.ecommerce.type.Role;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CartServiceImplementTest {
+
+  @Mock
+  private CartRepository cartRepository;
+
+  @Mock
+  private AuthService authService;
+
+  @Mock
+  private MemberService memberService;
+
+  @InjectMocks
+  private CartServiceImplement cartServiceImplement;
+
+  @Test
+  @DisplayName("장바구니 내역 조회 - 성공")
+  void testGetCartDetails_Success() {
+    // given
+    Member member = Member.builder()
+        .memberId("testUser")
+        .memberName("test")
+        .email("test@email.com")
+        .password("encodedPassword")
+        .phoneNumber("01011112222")
+        .address("test시 test구 test로 111")
+        .role(Role.CUSTOMER)
+        .loginType(LoginType.APP)
+        .build();
+
+    Product product1 = Product.builder()
+        .productName("testProductName1")
+        .description("testProductDescription1")
+        .stockQuantity(3)
+        .price(BigDecimal.valueOf(10001.0))
+        .status(ProductStatus.NO_STOCK)
+        .rating(BigDecimal.ZERO)
+        .member(new Member())
+        .build();
+
+    Product product2 = Product.builder()
+        .productName("testProductName2")
+        .description("testProductDescription2")
+        .stockQuantity(3)
+        .price(BigDecimal.valueOf(10002.0))
+        .status(ProductStatus.NO_STOCK)
+        .rating(BigDecimal.ZERO)
+        .member(new Member())
+        .build();
+
+    Cart cart = Cart.builder()
+        .member(member)
+        .cartItems(List.of())
+        .build();
+
+    cart.setCartItems(
+        List.of(
+            CartItem.builder()
+                .cart(cart)
+                .product(product1)
+                .price(product1.getPrice().multiply(BigDecimal.valueOf(3)))
+                .quantity(3)
+                .build(),
+            CartItem.builder()
+                .cart(cart)
+                .product(product2)
+                .price(product2.getPrice().multiply(BigDecimal.valueOf(2)))
+                .quantity(2)
+                .build()
+        )
+    );
+
+    willDoNothing().given(authService)
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    given(memberService.getMemberByMemberId(eq("testUser")))
+        .willReturn(member);
+    given(cartRepository.findByMember(member))
+        .willReturn(Optional.of(cart));
+
+    // when
+    CartDto cartDetails = cartServiceImplement.getCartDetails("testUser", "token");
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+    verify(memberService, times(1))
+        .getMemberByMemberId(eq("testUser"));
+    verify(cartRepository, times(1))
+        .findByMember(eq(member));
+
+    assertThat(cartDetails.getMemberId()).isEqualTo("testUser");
+    assertThat(cartDetails.getTotalPrice()).isEqualTo(BigDecimal.valueOf(50007.0));
+    assertThat(cartDetails.getCartItems().size()).isEqualTo(2);
+
+  }
+
+  @Test
+  @DisplayName("장바구니 내역 조회 - 실패 (토큰에 있는 멤버 정보와 불일치)")
+  void testGetCartDetails_Fail_MemberUnMatched() {
+    // given
+    doThrow(new MemberException(ResponseCode.MEMBER_UNMATCHED))
+        .when(authService).equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    // when
+    MemberException memberException = assertThrows(MemberException.class,
+        () -> cartServiceImplement.getCartDetails("testUser", "token"));
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    assertThat(memberException.getErrorCode()).isEqualTo(ResponseCode.MEMBER_UNMATCHED);
+  }
+
+  @Test
+  @DisplayName("장바구니 내역 조회 - 실패 (존재하지 않는 멤버)")
+  void testGetCartDetails_Fail_MemberNotFound() {
+    // given
+    willDoNothing().given(authService)
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    doThrow(new MemberException(ResponseCode.MEMBER_NOT_FOUND))
+        .when(memberService).getMemberByMemberId(eq("testUser"));
+
+    // when
+    MemberException memberException = assertThrows(MemberException.class,
+        () -> cartServiceImplement.getCartDetails("testUser", "token"));
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+    verify(memberService, times(1))
+        .getMemberByMemberId(eq("testUser"));
+
+    assertThat(memberException.getErrorCode()).isEqualTo(ResponseCode.MEMBER_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("장바구니 내역 조회 - 실패 (존재하지 않는 장바구니)")
+  void testGetCartDetails_Fail_CartNotFound() {
+    // given
+    Member member = Member.builder()
+        .memberId("testUser")
+        .memberName("test")
+        .email("test@email.com")
+        .password("encodedPassword")
+        .phoneNumber("01011112222")
+        .address("test시 test구 test로 111")
+        .role(Role.CUSTOMER)
+        .loginType(LoginType.APP)
+        .build();
+
+    willDoNothing().given(authService)
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+
+    given(memberService.getMemberByMemberId(eq("testUser")))
+        .willReturn(member);
+    given(cartRepository.findByMember(member))
+        .willReturn(Optional.empty());
+
+    // when
+    CartException cartException = assertThrows(CartException.class,
+        () -> cartServiceImplement.getCartDetails("testUser", "token"));
+
+    // then
+    verify(authService, times(1))
+        .equalToMemberIdFromToken(eq("testUser"), eq("token"));
+    verify(memberService, times(1))
+        .getMemberByMemberId(eq("testUser"));
+    verify(cartRepository, times(1))
+        .findByMember(eq(member));
+
+    assertThat(cartException.getErrorCode()).isEqualTo(ResponseCode.CART_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("Member Id 로 카트 조회 - 성공")
+  void testGetCartByMemberId_Success() {
+    // given
+    Member member = Member.builder()
+        .memberId("testUser")
+        .memberName("test")
+        .email("test@email.com")
+        .password("encodedPassword")
+        .phoneNumber("01011112222")
+        .address("test시 test구 test로 111")
+        .role(Role.CUSTOMER)
+        .loginType(LoginType.APP)
+        .build();
+
+    Cart cart = Cart.builder()
+        .member(member)
+        .cartItems(List.of())
+        .build();
+
+    given(memberService.getMemberByMemberId(eq("testUser"))).willReturn(member);
+    given(cartRepository.findByMember(eq(member))).willReturn(Optional.ofNullable(cart));
+
+    // when
+    Cart foundCart = cartServiceImplement.getCartByMemberId("testUser");
+
+    // then
+    assertThat(foundCart.getMember().getMemberId()).isEqualTo("testUser");
+  }
+
+  @Test
+  @DisplayName("Member Id 로 카트 조회 - 실패 (존재하지 않는 멤버)")
+  void testGetCartByMemberId_Fail_MemberNotFound() {
+    // given
+    doThrow(new MemberException(ResponseCode.MEMBER_NOT_FOUND))
+        .when(memberService).getMemberByMemberId(eq("testUser"));
+
+    // when
+    MemberException memberException = assertThrows(MemberException.class,
+        () -> cartServiceImplement.getCartByMemberId("testUser"));
+
+    // then
+    assertThat(memberException.getErrorCode()).isEqualTo(ResponseCode.MEMBER_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("Member Id 로 카트 조회 - 실패 (존재하지 않는 장바구니)")
+  void testGetCartByMemberId_Fail_CartNotFound() {
+    // given
+    Member member = Member.builder()
+        .memberId("testUser")
+        .memberName("test")
+        .email("test@email.com")
+        .password("encodedPassword")
+        .phoneNumber("01011112222")
+        .address("test시 test구 test로 111")
+        .role(Role.CUSTOMER)
+        .loginType(LoginType.APP)
+        .build();
+
+    given(memberService.getMemberByMemberId(eq("testUser"))).willReturn(member);
+    given(cartRepository.findByMember(eq(member))).willReturn(Optional.empty());
+
+    // when
+    CartException cartException = assertThrows(CartException.class,
+        () -> cartServiceImplement.getCartByMemberId("testUser"));
+
+    // then
+    assertThat(cartException.getErrorCode()).isEqualTo(ResponseCode.CART_NOT_FOUND);
+  }
+
+}

--- a/src/test/java/com/ecommerce/service/member/MemberServiceImplementTest.java
+++ b/src/test/java/com/ecommerce/service/member/MemberServiceImplementTest.java
@@ -228,7 +228,7 @@ class MemberServiceImplementTest {
         .build();
 
     given(memberRepository.findByMemberId(eq("testUser")))
-        .willReturn(Optional.ofNullable(member));
+        .willReturn(Optional.of(member));
 
     // when
     ResponseDto responseDto = memberServiceImplement.deleteMember("testUser", "token");
@@ -238,6 +238,8 @@ class MemberServiceImplementTest {
         .equalToMemberIdFromToken(eq("testUser"), eq("token"));
     verify(memberRepository, times(1))
         .findByMemberId(eq("testUser"));
+    verify(memberRepository, times(1))
+        .delete(eq(member));
 
     assertThat(responseDto.getCode()).isEqualTo(ResponseCode.MEMBER_DELETE_SUCCESS);
   }

--- a/src/test/java/com/ecommerce/service/product/ProductServiceImplementTest.java
+++ b/src/test/java/com/ecommerce/service/product/ProductServiceImplementTest.java
@@ -864,7 +864,7 @@ class ProductServiceImplementTest {
         .member(member)
         .build();
 
-    given(productRepository.findById(1L)).willReturn(Optional.ofNullable(product));
+    given(productRepository.findById(1L)).willReturn(Optional.of(product));
 
     willDoNothing().given(authService)
         .equalToMemberIdFromToken(eq(member.getMemberId()), eq("token"));
@@ -876,6 +876,8 @@ class ProductServiceImplementTest {
     verify(productRepository, times(1)).findById(eq(1L));
     verify(authService, times(1))
         .equalToMemberIdFromToken(eq(member.getMemberId()), eq("token"));
+    verify(productRepository, times(1))
+        .delete(eq(product));
 
     assertThat(responseDto.getCode()).isEqualTo(ResponseCode.PRODUCT_DELETE_SUCCESS);
   }


### PR DESCRIPTION
### Pull Request

> ### 제목
>
> - Feat: CartException.java 생성 및 GlobalExceptionHandler.java 에 추가
> - Feat: Cart, CartItem Entity 생성 및 CartDto, CartItemDto 생성
> - Feat: 회원 가입 및 소셜 로그인시 장바구니 생성
> - Feat: 특정 유저의 장바구니 목록 조회
> - Fix: Table 'ecommerce.cart_item' doesn't exist 에러 해결
> - Feat: 장바구니에 상품 담기 기능 구현
> - Style: 코드 스타일 정렬
> - Fix: 장바구니에 상품 담기 기능 수정
> - Refactor: 사용하지 않는 import 제거
> - Feat: 장바구니 상품 수량 수정
> - Feat: 장바구니 상품 삭제
> - Feat: 장바구니 상품 전체 제거
> - Refactor: 장바구니 목록 조회, 장바구니 상품 추가, 수정, 삭제, 전체 삭제 API End Point URI 변경

> ### 변경사항
> 
> 📌 **AS-IS**
> - Builder.Default 를 활용해 ProductStatus 초기값 설정
> - 상품 등록, 조회, 수정, 삭제 테스트 코드 작성
>
> 🔖 **TO-BE**
>  🔧 장바구니 목록 조회, 장바구니 상품 추가, 수정, 삭제, 전체삭제 기능 구현
> - Cart, CartItem Entity 생성 및 CartDto, CartItemDto 생성
>     - CartDto 의 fromEntity 에서 cartItems 요소들의 가격의 총합을 계산해서 total_price 필드로 응답
>     - CartItemDto 의 fromEntity 에서 상품 가격에 장바구니의 상품 갯수 만큼의 합산을 price 필드로 응답
>
> - 회원 가입 및 소셜 로그인시 장바구니 생성
>     - 일반 회원 회원가입시 회원 권한이 CUSTOMER 인 회원만 장바구니 생성
>     - 소셜 로그인시 Cart 테이블에 소셜 로그인한 사용자의 ID 를 가지는 장바구니가 없다면 생성
>
> - Table 'ecommerce.cart_item' doesn't exist 에러 해결
>      - Table 이름이 CartItem 처럼 카멜 케이스 일 때 hibernate 의 기본 매핑 규칙을 따라
>          hibernate 가 자동으로 카멜 케이스 -> 스네이크 케이스 (cartItem -> cart_item) 로
>          변경해서 CartItem 테이블이 아니라 cart_item 테이블을 참조하려는 에러가 발생
>
>      - 해결방법
>          1. 테이블 이름을 CartItem -> Cart_Item 으로 변경
>          2. application.yml 에
>              spring:
>                jpa:
>                  hibernate:
>                      naimg:
>                         physical-strategy:   org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl 추가
>
> - 장바구니에 상품 담기 기능 구현
>    - PreAuthorize 어노테이션으로 회원 권한이 CUSTOMER 인 유저만 요청 가능하도록 설정
>    - Path Variable 로 받는 memberId 와 token 에 있는 memberId 가 동일한지 확인
>    - memberId 에 해당하는 cart 객체와 request 로 받은 productId 에 해당하는 product 객체 조호후
>      product 객체가 활성화 되어있는지 상태를 확인 하고 cart, product 객체를 함께 가지는 cartItem 이 있는지 확인
>    - 위의 조건이 통과되면 데이터 저장하고 성공 응답
>
> - 장바구니에 상품 담기 기능 수정
>    - 장바구니에 상품 단기 성공후 응답 ResponseDto 에서 CartItemDto.Response 로 변경
>
> - 장바구니 상품 수량 수정
>    - Path Variable 로 받은 memberId 와 token 에 있는 memberId 동일한지 확인
>    - cartItemId 를 가지는 cartItem 이 존재하는지 확인
>    - 수정 하려는 장바구니 상품 수량이 상품의 재고보다 큰지 확인후 크지 않다면 수정하여 응답 구현
>
> - 장바구니 상품 삭제
>    - Path Variable 로 받은 memberId 와 token 에 있는 memberId 일치 확인
>    - cartItemId 에 해당하는 장바구니 상품이 있는지 확인 후 있다면 삭제하고 성공 응답
>
> - 장바구니 상품 전체 제거
>    - Path Variable 로 받은 memberId 와 token 에 있는 memberId 일치 확인
>    - memberId 에 해당하는 cart 객체를 포함하는 모든 cartItem 데이터 삭제후 성공 응답

> ### 테스트
>
> - [ ] 테스트 코드
> - [x] API 테스트